### PR TITLE
fix: Replace unwrap()/expect() with proper error handling (closes #7)

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -16,6 +16,6 @@ impl Database {
     }
 
     pub fn connection(&self) -> std::sync::MutexGuard<'_, Connection> {
-        self.conn.lock().unwrap()
+        self.conn.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }

--- a/src-tauri/src/infrastructure/file_scanner.rs
+++ b/src-tauri/src/infrastructure/file_scanner.rs
@@ -81,7 +81,7 @@ impl<'a> FileScanner<'a> {
                     [file_path],
                     |row| row.get(0),
                 )
-                .unwrap_or(false);
+                .with_context(|| format!("Failed to check if asset exists: {}", file_path))?;
 
             if !exists {
                 tx.execute(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod db;
 mod domain;
 mod infrastructure;
 
-use db::{ Database, migrations };
+use db::{Database, migrations};
 use std::sync::Mutex;
 use tauri::Manager;
 
@@ -12,16 +12,17 @@ use tauri::Manager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .setup(|app| {
+        .setup(|app| -> anyhow::Result<()> {
             let app_data_dir = app
                 .path()
                 .app_data_dir()
-                .expect("Failed to get app data dir");
-            std::fs::create_dir_all(&app_data_dir).expect("Failed to create app data dir");
+                .context("Failed to get app data dir")?;
+            std::fs::create_dir_all(&app_data_dir)
+                .context("Failed to create app data dir")?;
 
             let db_path = app_data_dir.join("lumine.db");
-            let db = Database::new(&db_path).expect("Failed to initialize database");
-            migrations::run_migrations(&db.connection()).expect("Failed to run migrations");
+            let db = Database::new(&db_path).context("Failed to initialize database")?;
+            migrations::run_migrations(&db.connection()).context("Failed to run migrations")?;
 
             app.manage(Mutex::new(db));
             Ok(())


### PR DESCRIPTION
## Summary
- `lib.rs`: `.expect()` を `anyhow::Context` + `?` に置換し起動時エラーを適切に伝播
- `db/mod.rs`: `unwrap()` を `unwrap_or_else` に置換しMutex poison状態からの回復を実装
- `file_scanner.rs`: `.unwrap_or(false)` を `with_context` + `?` に置換しDBエラー伝播を実装

## Issue
#7