### PR TITLE
fix: Initialize JobSystem and emit scan progress events (closes #10)

### DIFF
--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -2,8 +2,9 @@ use crate::application::LibraryService;
 use crate::db::Database;
 use crate::domain::Library;
 use crate::infrastructure::FileScanner;
+use crate::jobs::JobSystem;
 use std::sync::Mutex;
-use tauri::State;
+use tauri::{Emitter, State};
 
 #[tauri::command]
 pub fn get_app_bootstrap(state: State<'_, Mutex<Database>>) -> Result<BootstrapData, String> {
@@ -41,15 +42,23 @@ pub fn remove_library(state: State<'_, Mutex<Database>>, library_id: i64) -> Res
 #[tauri::command]
 pub fn scan_library(
     state: State<'_, Mutex<Database>>,
+    job_system: State<'_, JobSystem>,
     library_id: i64,
 ) -> Result<ScanResult, String> {
+    let job_id = format!("scan_{}_{}", library_id, chrono::Utc::now().timestamp());
+    let _ = job_system.app_handle().emit("job_started", &job_id);
+
     let db = state.lock().map_err(|e| e.to_string())?;
     let library_service = LibraryService::new(&db);
     let library = library_service.get_library(library_id).map_err(|e| e.to_string())?;
     let scanner = FileScanner::new(&db);
-    scanner
+    let result = scanner
         .scan_library(library_id, &library.root_path)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    let _ = job_system.app_handle().emit("job_completed", &job_id);
+
+    Ok(result)
 }
 
 #[derive(serde::Serialize)]

--- a/src-tauri/src/jobs/background.rs
+++ b/src-tauri/src/jobs/background.rs
@@ -1,5 +1,4 @@
 use crate::db::Database;
-use anyhow::Result;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Mutex;
 use std::thread;
@@ -13,16 +12,18 @@ pub enum JobCommand {
 
 pub struct JobSystem {
     sender: Sender<JobCommand>,
+    app_handle: AppHandle,
 }
 
 impl JobSystem {
     pub fn new(db: std::sync::Arc<Database>, app_handle: AppHandle) -> Self {
         let (sender, receiver) = channel::<JobCommand>();
         let db_clone = db.clone();
+        let app_handle_clone = app_handle.clone();
         thread::spawn(move || {
-            Self::worker(db_clone, app_handle, receiver);
+            Self::worker(db_clone, app_handle_clone, receiver);
         });
-        Self { sender }
+        Self { sender, app_handle }
     }
 
     fn worker(db: std::sync::Arc<Database>, app_handle: AppHandle, receiver: Receiver<JobCommand>) {
@@ -41,6 +42,10 @@ impl JobSystem {
                 }
             }
         }
+    }
+
+    pub fn app_handle(&self) -> AppHandle {
+        self.app_handle.clone()
     }
 
     pub fn queue_scan(&self, library_id: i64) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,11 @@ mod commands;
 mod db;
 mod domain;
 mod infrastructure;
+mod jobs;
 
 use db::{Database, migrations};
-use std::sync::Mutex;
+use jobs::JobSystem;
+use std::sync::{Arc, Mutex};
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -24,7 +26,10 @@ pub fn run() {
             let db = Database::new(&db_path).context("Failed to initialize database")?;
             migrations::run_migrations(&db.connection()).context("Failed to run migrations")?;
 
+            let db_arc = Arc::new(db);
             app.manage(Mutex::new(db));
+            app.manage(JobSystem::new(db_arc, app.handle().clone()));
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Summary
- `lib.rs`: Add `mod jobs` and initialize `JobSystem` in `setup`
- `background.rs`: Add `app_handle` field and `app_handle()` accessor method
- `library.rs`: Emit `job_started`/`job_completed` events during scan

## Issue
#10