### PR TITLE
fix: 検索機能の実装 - SearchInputとAssetGridの連携 (closes #9)

### DIFF
--- a/src/app/layout/SearchInput.tsx
+++ b/src/app/layout/SearchInput.tsx
@@ -1,15 +1,17 @@
-import { useState, useCallback, type ChangeEvent } from "react";
+import { useCallback, type ChangeEvent } from "react";
 import { SearchIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { useAppStore } from "@/shared/hooks/useAppStore";
 
 export function SearchInput() {
-  const [value, setValue] = useState("");
+  const searchQuery = useAppStore((s) => s.searchQuery);
+  const setSearchQuery = useAppStore((s) => s.setSearchQuery);
 
   const handleSearch = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
+      setSearchQuery(e.target.value);
     },
-    []
+    [setSearchQuery]
   );
 
   return (
@@ -18,7 +20,7 @@ export function SearchInput() {
       <Input
         type="search"
         placeholder="Search assets..."
-        value={value}
+        value={searchQuery}
         onChange={handleSearch}
         className="pl-9"
       />

--- a/src/features/asset-grid/AssetGrid.tsx
+++ b/src/features/asset-grid/AssetGrid.tsx
@@ -10,12 +10,14 @@ export function AssetGrid() {
   const parentRef = useRef<HTMLDivElement>(null);
   const selectedLibraryId = useAppStore((s) => s.selectedLibraryId);
   const thumbnailSize = useAppStore((s) => s.thumbnailSize);
+  const searchQuery = useAppStore((s) => s.searchQuery);
 
   const { data: assets = [], isLoading } = useQuery({
-    queryKey: ["assets", selectedLibraryId],
+    queryKey: ["assets", selectedLibraryId, searchQuery],
     queryFn: () =>
       listAssets({
         library_id: selectedLibraryId ?? undefined,
+        search: searchQuery || undefined,
         limit: 1000,
       }),
     enabled: selectedLibraryId !== null,

--- a/src/shared/hooks/useAppStore.ts
+++ b/src/shared/hooks/useAppStore.ts
@@ -15,8 +15,10 @@ interface AppState {
   isDetailPanelOpen: boolean;
   isScanning: boolean;
   scanProgress: { added: number; unchanged: number; errors: number } | null;
+  searchQuery: string;
 
   setLibraries: (libraries: Library[]) => void;
+  setSearchQuery: (query: string) => void;
   selectLibrary: (id: number | null) => void;
   addLibrary: (library: Library) => void;
   removeLibrary: (id: number) => void;
@@ -53,8 +55,10 @@ export const useAppStore = create<AppState>((set) => ({
   isDetailPanelOpen: false,
   isScanning: false,
   scanProgress: null,
+  searchQuery: "",
 
   setLibraries: (libraries) => set({ libraries }),
+  setSearchQuery: (query) => set({ searchQuery: query }),
   selectLibrary: (id) => set({ selectedLibraryId: id }),
   addLibrary: (library) =>
     set((state) => ({ libraries: [...state.libraries, library] })),


### PR DESCRIPTION
## 概要
- `useAppStore`: `searchQuery` 状態と `setSearchQuery` 関数を追加
- `SearchInput.tsx`: ローカル state から Zustand store を使用するよう変更
- `AssetGrid.tsx`: `listAssets` 呼び出し時に `search` パラメータを渡すよう修正

## Issue
#9