### PR TITLE
fix: サイドバーのTags/Posts/SettingsボタンにonClickを追加 (closes #11)

### DIFF
--- a/src/app/layout/Sidebar.tsx
+++ b/src/app/layout/Sidebar.tsx
@@ -18,6 +18,8 @@ interface SidebarProps {
 export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const selectedLibraryId = useAppStore((s) => s.selectedLibraryId);
   const selectLibrary = useAppStore((s) => s.selectLibrary);
+  const activeView = useAppStore((s) => s.activeView);
+  const setActiveView = useAppStore((s) => s.setActiveView);
 
   const { data: libraries = [] } = useQuery({
     queryKey: ["libraries"],
@@ -72,20 +74,41 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
           </div>
         </div>
 
-        <button className="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm hover:bg-accent/50">
-          <TagsIcon className="w-4 h-4" />
-          {!collapsed && <span>Tags</span>}
-        </button>
+<button
+        onClick={() => setActiveView("tags")}
+        className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors ${
+          activeView === "tags"
+            ? "bg-accent text-accent-foreground"
+            : "hover:bg-accent/50"
+        }`}
+      >
+        <TagsIcon className="w-4 h-4" />
+        {!collapsed && <span>Tags</span>}
+      </button>
 
-        <button className="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm hover:bg-accent/50">
-          <FileImageIcon className="w-4 h-4" />
-          {!collapsed && <span>Posts</span>}
-        </button>
+      <button
+        onClick={() => setActiveView("posts")}
+        className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors ${
+          activeView === "posts"
+            ? "bg-accent text-accent-foreground"
+            : "hover:bg-accent/50"
+        }`}
+      >
+        <FileImageIcon className="w-4 h-4" />
+        {!collapsed && <span>Posts</span>}
+      </button>
 
-        <button className="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm hover:bg-accent/50">
-          <SettingsIcon className="w-4 h-4" />
-          {!collapsed && <span>Settings</span>}
-        </button>
+      <button
+        onClick={() => setActiveView("settings")}
+        className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors ${
+          activeView === "settings"
+            ? "bg-accent text-accent-foreground"
+            : "hover:bg-accent/50"
+        }`}
+      >
+        <SettingsIcon className="w-4 h-4" />
+        {!collapsed && <span>Settings</span>}
+      </button>
       </nav>
     </aside>
   );

--- a/src/shared/hooks/useAppStore.ts
+++ b/src/shared/hooks/useAppStore.ts
@@ -16,9 +16,11 @@ interface AppState {
   isScanning: boolean;
   scanProgress: { added: number; unchanged: number; errors: number } | null;
   searchQuery: string;
+  activeView: "assets" | "tags" | "posts" | "settings";
 
   setLibraries: (libraries: Library[]) => void;
   setSearchQuery: (query: string) => void;
+  setActiveView: (view: "assets" | "tags" | "posts" | "settings") => void;
   selectLibrary: (id: number | null) => void;
   addLibrary: (library: Library) => void;
   removeLibrary: (id: number) => void;
@@ -56,9 +58,11 @@ export const useAppStore = create<AppState>((set) => ({
   isScanning: false,
   scanProgress: null,
   searchQuery: "",
+  activeView: "assets",
 
   setLibraries: (libraries) => set({ libraries }),
   setSearchQuery: (query) => set({ searchQuery: query }),
+  setActiveView: (view) => set({ activeView: view }),
   selectLibrary: (id) => set({ selectedLibraryId: id }),
   addLibrary: (library) =>
     set((state) => ({ libraries: [...state.libraries, library] })),


### PR DESCRIPTION
## 概要
- `useAppStore`: `activeView` 状態と `setActiveView` 関数を追加
- `Sidebar.tsx`: Tags/Posts/SettingsボタンにonClickハンドラとアクティブ状態スタイルを追加

## Issue
#11