### PR TITLE
fix: transaction() を使用してロールバックを正しく処理 (closes #18)

### DIFF
--- a/src-tauri/src/infrastructure/file_scanner.rs
+++ b/src-tauri/src/infrastructure/file_scanner.rs
@@ -25,7 +25,7 @@ impl<'a> FileScanner<'a> {
 
         let mut result = ScanResult::default();
         let conn = self.db.connection();
-        let tx = conn.unchecked_transaction()?;
+        let mut tx = conn.transaction()?;
 
         for entry in WalkDir::new(root)
             .follow_links(false)


### PR DESCRIPTION
## 概要
- `unchecked_transaction()` を `transaction()` に変更
- スキャンエラー発生時に自動的にロールバックされるように

## Issue
#18