### PR TITLE
fix: tauri.conf.json のdevtools設定を修正

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,10 +7,10 @@
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
-    "frontendDist": "../dist",
-    "devtools": true
+    "frontendDist": "../dist"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "title": "Lumine",


### PR DESCRIPTION
## 概要
`build` セクション内の `devtools` プロパティを削除
Tauri v2ではこの形式はサポートされていません

## Issue
ビルドエラー対応