### PR TITLE
fix: Windows build workflow のコンパイルエラーを修正

### DIFF
--- a/src-tauri/src/application/services.rs
+++ b/src-tauri/src/application/services.rs
@@ -1,6 +1,6 @@
 use crate::db::Database;
 use crate::domain::{
-    Asset, AssetQuery, Library, MoveConflictPolicy, Post, PostAccount, PostStatus, PostTarget,
+    Asset, AssetQuery, Library, Post, PostAccount, PostStatus, PostTarget,
     SortField, SortOrder, StatusLabel, Tag, ThumbStatus,
 };
 use anyhow::{Context, Result};

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -1,7 +1,7 @@
 use crate::application::LibraryService;
 use crate::db::Database;
 use crate::domain::Library;
-use crate::infrastructure::FileScanner;
+use crate::infrastructure::{file_scanner::ScanResult, FileScanner};
 use crate::jobs::JobSystem;
 use std::sync::Mutex;
 use tauri::{Emitter, State};
@@ -64,11 +64,4 @@ pub fn scan_library(
 #[derive(serde::Serialize)]
 pub struct BootstrapData {
     pub libraries: Vec<Library>,
-}
-
-#[derive(serde::Serialize)]
-pub struct ScanResult {
-    pub added: u32,
-    pub unchanged: u32,
-    pub errors: u32,
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2,6 +2,8 @@ use rusqlite::{Connection, Result};
 use std::path::Path;
 use std::sync::Mutex;
 
+pub mod migrations;
+
 pub struct Database {
     pub conn: Mutex<Connection>,
 }

--- a/src-tauri/src/infrastructure/file_scanner.rs
+++ b/src-tauri/src/infrastructure/file_scanner.rs
@@ -25,7 +25,7 @@ impl<'a> FileScanner<'a> {
 
         let mut result = ScanResult::default();
         let mut conn = self.db.connection();
-        let mut tx = conn.transaction()?;
+        let tx = conn.transaction()?;
 
         for entry in WalkDir::new(root)
             .follow_links(false)

--- a/src-tauri/src/jobs/background.rs
+++ b/src-tauri/src/jobs/background.rs
@@ -1,6 +1,5 @@
 use crate::db::Database;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Mutex;
 use std::thread;
 use tauri::{AppHandle, Emitter};
 
@@ -26,7 +25,7 @@ impl JobSystem {
         Self { sender, app_handle }
     }
 
-    fn worker(db: std::sync::Arc<Database>, app_handle: AppHandle, receiver: Receiver<JobCommand>) {
+    fn worker(_db: std::sync::Arc<Database>, app_handle: AppHandle, receiver: Receiver<JobCommand>) {
         while let Ok(command) = receiver.recv() {
             match command {
                 JobCommand::ScanLibrary { library_id } => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ use tauri::Manager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .setup(|app| -> anyhow::Result<()> {
+        .setup(|app: &mut tauri::App| -> anyhow::Result<()> {
             let app_data_dir = app
                 .path()
                 .app_data_dir()


### PR DESCRIPTION
## Purpose
GitHub Actions の `build-windows.yml` ワークフローで発生している Rust コンパイルエラーを修正する。

## Changes
- `db/mod.rs` に `pub mod migrations;` を追加 (E0432 修正)
- `commands/library.rs` で重複定義されていた `ScanResult` を削除し、`infrastructure::file_scanner::ScanResult` を参照するよう修正 (E0308 修正)
- `lib.rs` の setup クロージャに型注釈 `|app: &mut tauri::App|` を追加 (E0282 修正)
- 未使用インポート `MoveConflictPolicy`, `std::sync::Mutex` を削除
- `file_scanner.rs` の不要な `mut` を削除
- `background.rs` の未使用変数 `db` を `_db` に変更

## Validation
- `npm run typecheck` パス
- `npm run build` パス
- 修正内容はローカルで確認済み（Rust の cargo check は WSL 環境に Rust toolchain が未インストールのため実行不可、CI上で確認）

## Impact
- Rust バックエンドのコンパイル関連のみ
- フロントエンドへの影響なし

Closes #26