### PR TITLE
fix: convertFileSrc を使用してサムネイル表示のカスタムプロトコル問題を修正

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "core:asset:default"
   ]
 }

--- a/src/features/asset-detail/AssetDetailPanel.tsx
+++ b/src/features/asset-detail/AssetDetailPanel.tsx
@@ -5,6 +5,7 @@ import { updateAssetNote, setAssetRating, setAssetStatus, setAssetFavorite } fro
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { XIcon, StarIcon } from "lucide-react";
+import { convertFileSrc } from "@tauri-apps/api/core";
 
 export function AssetDetailPanel() {
   const selectedAsset = useAppStore((s) => s.selectedAsset);
@@ -71,7 +72,7 @@ export function AssetDetailPanel() {
       <div className="flex-1 overflow-auto p-4 space-y-4">
         <div>
           <img
-            src={`asset://localhost/thumb/${selectedAsset.id}`}
+            src={convertFileSrc(selectedAsset.file_path)}
             alt={selectedAsset.file_name}
             className="w-full rounded-md bg-muted"
           />

--- a/src/features/asset-grid/AssetGridItem.tsx
+++ b/src/features/asset-grid/AssetGridItem.tsx
@@ -2,6 +2,7 @@ import type { MouseEvent } from "react";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import type { Asset } from "@/entities/types";
 import { StarIcon } from "lucide-react";
+import { convertFileSrc } from "@tauri-apps/api/core";
 
 interface AssetGridItemProps {
   asset: Asset;
@@ -22,7 +23,7 @@ export function AssetGridItem({ asset, size }: AssetGridItemProps) {
     }
   };
 
-  const thumbUrl = `asset://localhost/thumb/${asset.id}`;
+  const thumbUrl = convertFileSrc(asset.file_path);
 
   return (
     <div


### PR DESCRIPTION
## Purpose
未実装の `asset://localhost/thumb/` カスタムプロトコルに依存していたサムネイル表示を、Tauri の `convertFileSrc` を使った実ファイル参照に修正。

## Changes
- `AssetGridItem.tsx`: `asset://localhost/thumb/{id}` を `convertFileSrc(file_path)` に変更
- `AssetDetailPanel.tsx`: 同上
- `capabilities/default.json`: `core:asset:default` パーミッションを追加

## Validation
- `npm run typecheck` パス
- `npm run build` パス

## Impact
- フロントエンドのサムネイル表示ロジック
- Tauri の capabilities 設定

Closes #31