### PR TITLE
security: CSP の null 設定を適切なポリシーに修正

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' https://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Purpose
`tauri.conf.json` で CSP が `null` に設定され、すべての Content Security Policy が無効化されていたセキュリティリスクを修正。

## Changes
- `tauri.conf.json`: `"csp": null` を `"default-src 'self'; img-src 'self' https://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'"` に変更

## Validation
- `npm run typecheck` パス

## Impact
- Tauri のセキュリティ設定のみ
- フロントエンド / バックエンドのロジック変更なし

Closes #30