### PR TITLE
fix: 評価値に 0-5 の範囲バリデーションを追加 #32

### DIFF
--- a/src-tauri/src/commands/asset.rs
+++ b/src-tauri/src/commands/asset.rs
@@ -86,6 +86,9 @@ pub fn set_asset_rating(
     asset_id: i64,
     rating: i32,
 ) -> Result<(), String> {
+    if !(0..=5).contains(&rating) {
+        return Err(format!("Rating must be between 0 and 5, got {}", rating));
+    }
     let db = state.lock().map_err(|e| e.to_string())?;
     let service = AssetService::new(&db);
     service.set_asset_rating(asset_id, rating).map_err(|e| e.to_string())


### PR DESCRIPTION
## Purpose
set_asset_rating コマンドが任意の i32 を受け入れていたが、DB 制約が CHECK(rating >= 0 AND rating <= 5) のため、範囲外の値で SQLite エラーが発生していた。フロント側でバリデーションを追加。

## Changes
- commands/asset.rs: set_asset_rating に 0..=5 の範囲チェックを追加

Closes #32