### PR TITLE
fix: set_asset_status のステータス値バリデーションを追加 #33

### DIFF
--- a/src-tauri/src/commands/asset.rs
+++ b/src-tauri/src/commands/asset.rs
@@ -100,6 +100,13 @@ pub fn set_asset_status(
     asset_id: i64,
     status: String,
 ) -> Result<(), String> {
+    const VALID_STATUSES: &[&str] = &["unorganized", "selected", "posting_candidate", "posted"];
+    if !VALID_STATUSES.contains(&status.as_str()) {
+        return Err(format!(
+            "Invalid status '{}'. Valid values: {:?}",
+            status, VALID_STATUSES
+        ));
+    }
     let db = state.lock().map_err(|e| e.to_string())?;
     let service = AssetService::new(&db);
     let status_label = StatusLabel::from(status.as_str());


### PR DESCRIPTION
## Purpose
set_asset_status が不正なステータス文字列を受け取った場合に、黙って Unorganized に変換せずエラーを返すよう修正。

## Changes
- commands/asset.rs: set_asset_status にバリデーションを追加し、不正値ならエラーを返す

Closes #33