### PR TITLE
fix: マイグレーションSQLを include_str! でコンパイル時埋め込みに変更 #35

### DIFF
--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1,31 +1,9 @@
 use rusqlite::Connection;
-use std::fs;
-use std::path::Path;
 
-const MIGRATIONS_DIR: &str = "migrations";
+const INITIAL_SCHEMA: &str = include_str!("../../migrations/001_initial_schema.sql");
+const MIGRATION_VERSION: u32 = 1;
 
 pub fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
-    let migrations_path = Path::new(MIGRATIONS_DIR);
-    if !migrations_path.exists() {
-        return Ok(());
-    }
-
-    let mut migrations: Vec<(u32, String)> = Vec::new();
-    for entry in fs::read_dir(migrations_path)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) == Some("sql") {
-            if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
-                if let Some(version) = name.split('_').next().and_then(|s| s.parse::<u32>().ok()) {
-                    let content = fs::read_to_string(&path)?;
-                    migrations.push((version, content));
-                }
-            }
-        }
-    }
-
-    migrations.sort_by_key(|(v, _)| *v);
-
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS schema_migrations (
             version INTEGER PRIMARY KEY,
@@ -33,27 +11,25 @@ pub fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
         )",
     )?;
 
-    for (version, sql) in migrations {
-        let exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = ?)",
-            [version],
-            |row| row.get(0),
-        )?;
+    let applied: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = ?)",
+        [MIGRATION_VERSION],
+        |row| row.get(0),
+    )?;
 
-        if !exists {
-            let tx = conn.unchecked_transaction()?;
-            for statement in sql.split(';') {
-                let trimmed = statement.trim();
-                if !trimmed.is_empty() {
-                    tx.execute(trimmed, [])?;
-                }
+    if !applied {
+        let tx = conn.unchecked_transaction()?;
+        for statement in INITIAL_SCHEMA.split(';') {
+            let trimmed = statement.trim();
+            if !trimmed.is_empty() {
+                tx.execute(trimmed, [])?;
             }
-            tx.execute(
-                "INSERT INTO schema_migrations (version) VALUES (?)",
-                [version],
-            )?;
-            tx.commit()?;
         }
+        tx.execute(
+            "INSERT INTO schema_migrations (version) VALUES (?)",
+            [MIGRATION_VERSION],
+        )?;
+        tx.commit()?;
     }
 
     Ok(())


### PR DESCRIPTION
## Purpose
マイグレーションのパス解決がカレントディレクトリ相対で、ビルド後アプリで migrations ディレクトリが見つからず失敗する問題を修正。

## Changes
- db/migrations.rs: ファイルシステム読み取りを `include_str!` マクロによるコンパイル時埋め込みに変更
- 不要になった `std::fs`、`std::path` インポートを削除

Closes #35