### PR TITLE
fix: CI に lint, cargo check を追加し cargo test のエラー無視を修正 #36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,29 @@ jobs:
           shared-key: "lumine-rust"
           cache-targets: false
 
+      - name: Lint
+        run: npm run lint || true
+        continue-on-error: true
+
       - name: Typecheck
         run: npm run typecheck
 
       - name: Frontend tests
         run: npm run test
 
+      - name: Rust check
+        run: cargo check --manifest-path src-tauri/Cargo.toml --all-targets --all-features
+
       - name: Rust fmt
-        run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check || true
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
         continue-on-error: true
 
       - name: Rust clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings || true
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
         continue-on-error: true
 
       - name: Rust tests
-        run: cargo test --manifest-path src-tauri/Cargo.toml --all || true
-        continue-on-error: true
+        run: cargo test --manifest-path src-tauri/Cargo.toml --all
 
       - name: Frontend build
         run: npm run build


### PR DESCRIPTION
## Purpose
ci.yml に lint ステップが欠落し、Rust のエラーが `|| true` + `continue-on-error` で無視されていた問題を修正。

## Changes
- npm run lint ステップを追加（開発中のため continue-on-error）
- cargo check ステップを追加（コンパイルエラーの早期検出）
- cargo fmt, cargo clippy: `|| true` を削除、continue-on-error は開発中なので維持
- cargo test: `|| true` と continue-on-error を削除し、エラーを検出するよう修正

Closes #36