### PR TITLE
fix: CI の Rust cache, Tauri system deps, lint step を修正 #45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           shared-key: "lumine-rust"
           cache-targets: false
+          workspaces: "src-tauri"
 
-      - name: Lint
-        run: npm run lint || true
-        continue-on-error: true
+      - name: Install Tauri system deps
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Typecheck
         run: npm run typecheck


### PR DESCRIPTION
## Purpose
#36 の修正により表面化した CI の残問題を修正。

## Changes
- Rust cache: `workspaces: "src-tauri"` を追加し Cargo.toml の場所を指定
- `Install Tauri system deps`: Tauri ビルドに必要なシステムパッケージを apt-get でインストール
- `Lint` ステップ: ESLint が未インストールのため削除（後日設定時に追加予定）

## Validation
- npm run typecheck パス

Closes #45