### PR TITLE
fix: capabilities の無効な core:asset:default 権限を削除 #47

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default",
-    "core:asset:default"
+    "opener:default"
   ]
 }


### PR DESCRIPTION
## Purpose
#31 で誤って追加した `core:asset:default` 権限が Tauri 2 に存在せず cargo check エラーとなる問題を修正。

## Changes
- capabilities/default.json: `core:asset:default` を削除（`convertFileSrc` は `core:default` に含まれている）

Closes #47