### PR TITLE
fix: Tauri 2.10.x の setup 戻り値型を Box<dyn Error> に修正 #49

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,17 +15,18 @@ use tauri::Manager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .setup(|app: &mut tauri::App| -> anyhow::Result<()> {
+        .setup(|app: &mut tauri::App| -> Result<(), Box<dyn std::error::Error>> {
             let app_data_dir = app
                 .path()
                 .app_data_dir()
-                .context("Failed to get app data dir")?;
-            std::fs::create_dir_all(&app_data_dir)
-                .context("Failed to create app data dir")?;
+                .map_err(|e| -> Box<dyn std::error::Error> { anyhow::anyhow!(e).into() })?;
+            std::fs::create_dir_all(&app_data_dir)?;
 
             let db_path = app_data_dir.join("lumine.db");
-            let db = Database::new(&db_path).context("Failed to initialize database")?;
-            migrations::run_migrations(&db.connection()).context("Failed to run migrations")?;
+            let db = Database::new(&db_path)
+                .map_err(|e| -> Box<dyn std::error::Error> { anyhow::anyhow!(e).into() })?;
+            migrations::run_migrations(&db.connection())
+                .map_err(|e| -> Box<dyn std::error::Error> { anyhow::anyhow!(e).into() })?;
 
             let db = Arc::new(Mutex::new(db));
             app.manage(db.clone());


### PR DESCRIPTION
## Purpose
Tauri 2.10.3 の `Builder::setup` が要求するクロージャの戻り値型 `Result<(), Box<dyn std::error::Error>>` に合わせるため、`anyhow::Result<()>` から型を変更。

## Changes
- lib.rs: setup クロージャの戻り値型を `Result<(), Box<dyn std::error::Error>>` に変更
- anyhow::Error を `.map_err(Into::into)` で Box<dyn Error> に変換

Closes #49