### PR TITLE
feat: build-windows.yml にポータブル exe アップロードを追加 #51

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,3 +44,9 @@ jobs:
         with:
           name: lumine-windows-bundles
           path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**
+
+      - name: Upload portable exe
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumine-windows-portable
+          path: src-tauri/target/x86_64-pc-windows-msvc/release/lumine.exe


### PR DESCRIPTION
## Purpose
MSI/NSIS インストーラーに加えて、インストール不要のポータブル `lumine.exe` も artifact としてアップロードする。

## Changes
- build-windows.yml: `Upload portable exe` ステップを追加し、`src-tauri/target/x86_64-pc-windows-msvc/release/lumine.exe` を `lumine-windows-portable` artifact としてアップロード

## 備考
WebView2 は Windows 10/11 にプリインストールされているため、`lumine.exe` 単体で動作可能。

Closes #51