### PR TITLE
fix: shadcn CSS の import パスを dist に修正 #53

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "shadcn/tailwind.css";
+@import "shadcn/dist/tailwind.css";
 @import "@fontsource-variable/geist";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Purpose
`@import "shadcn/tailwind.css"` が `"style"` exports condition で定義されているため Tailwind v4 の CSS パーサーが解決できなかった問題を修正。

## Changes
- `index.css`: `@import "shadcn/tailwind.css"` → `@import "shadcn/dist/tailwind.css"` に変更

Closes #53