### PR TITLE
fix: add error handling for Tauri commands with toast notifications

### DIFF
--- a/src/app/layout/Sidebar.tsx
+++ b/src/app/layout/Sidebar.tsx
@@ -8,7 +8,10 @@ import {
   TagsIcon,
   FileImageIcon,
   SettingsIcon,
+  AlertCircleIcon,
 } from "lucide-react";
+import { useToast } from "@/components/ui/toast";
+import { useEffect } from "react";
 
 interface SidebarProps {
   collapsed: boolean;
@@ -20,11 +23,18 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const selectLibrary = useAppStore((s) => s.selectLibrary);
   const activeView = useAppStore((s) => s.activeView);
   const setActiveView = useAppStore((s) => s.setActiveView);
+  const { addToast } = useToast();
 
-  const { data: libraries = [] } = useQuery({
+  const { data: libraries = [], isError, error } = useQuery({
     queryKey: ["libraries"],
     queryFn: listLibraries,
   });
+
+  useEffect(() => {
+    if (isError && error) {
+      addToast(`Failed to load libraries: ${error.message}`, "error");
+    }
+  }, [isError, error, addToast]);
 
   return (
     <aside
@@ -56,21 +66,34 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
             </span>
           )}
           <div className="mt-1 space-y-1">
-            {libraries.map((lib) => (
-              <button
-                key={lib.id}
-                onClick={() => selectLibrary(lib.id)}
-                className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors ${
-                  selectedLibraryId === lib.id
-                    ? "bg-accent text-accent-foreground"
-                    : "hover:bg-accent/50"
-                }`}
-                title={lib.name}
-              >
-                <FolderIcon className="w-4 h-4 shrink-0" />
-                {!collapsed && <span className="truncate">{lib.name}</span>}
-              </button>
-            ))}
+            {isError ? (
+              <div className="px-3 py-2 text-sm text-destructive flex items-center gap-2">
+                <AlertCircleIcon className="w-4 h-4" />
+                {!collapsed && <span>Failed to load</span>}
+              </div>
+            ) : libraries.length === 0 ? (
+              !collapsed && (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  No libraries yet
+                </div>
+              )
+            ) : (
+              libraries.map((lib) => (
+                <button
+                  key={lib.id}
+                  onClick={() => selectLibrary(lib.id)}
+                  className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors ${
+                    selectedLibraryId === lib.id
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-accent/50"
+                  }`}
+                  title={lib.name}
+                >
+                  <FolderIcon className="w-4 h-4 shrink-0" />
+                  {!collapsed && <span className="truncate">{lib.name}</span>}
+                </button>
+              ))
+            )}
           </div>
         </div>
 

--- a/src/app/providers/QueryProvider.tsx
+++ b/src/app/providers/QueryProvider.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/toast";
 
 export function QueryProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
@@ -12,11 +13,16 @@ export function QueryProvider({ children }: { children: ReactNode }) {
             retry: 1,
             refetchOnWindowFocus: false,
           },
+          mutations: {
+            retry: 0,
+          },
         },
       })
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,75 @@
+import { useState, useCallback, createContext, useContext, type ReactNode } from "react";
+import { XIcon, AlertCircleIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: "error" | "warning" | "info";
+}
+
+interface ToastContextType {
+  addToast: (message: string, type?: "error" | "warning" | "info") => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback(
+    (message: string, type: "error" | "warning" | "info" = "error") => {
+      const id = nextId++;
+      setToasts((prev) => [...prev, { id, message, type }]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 5000);
+    },
+    []
+  );
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`flex items-start gap-3 p-4 rounded-lg shadow-lg border ${
+              toast.type === "error"
+                ? "bg-destructive/10 border-destructive/30 text-destructive"
+                : toast.type === "warning"
+                ? "bg-yellow-50 border-yellow-300 text-yellow-800"
+                : "bg-blue-50 border-blue-300 text-blue-800"
+            }`}
+          >
+            <AlertCircleIcon className="w-5 h-5 mt-0.5 shrink-0" />
+            <p className="text-sm flex-1">{toast.message}</p>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="w-6 h-6 shrink-0"
+              onClick={() => removeToast(toast.id)}
+            >
+              <XIcon className="w-4 h-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/src/features/asset-detail/AssetDetailPanel.tsx
+++ b/src/features/asset-detail/AssetDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import { updateAssetNote, setAssetRating, setAssetStatus, setAssetFavorite } from "@/shared/api/client";
@@ -6,20 +6,29 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { XIcon, StarIcon } from "lucide-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { useToast } from "@/components/ui/toast";
 
 export function AssetDetailPanel() {
   const selectedAsset = useAppStore((s) => s.selectedAsset);
   const setSelectedAsset = useAppStore((s) => s.setSelectedAsset);
   const setDetailPanelOpen = useAppStore((s) => s.setDetailPanelOpen);
   const queryClient = useQueryClient();
+  const { addToast } = useToast();
 
   const [noteContent, setNoteContent] = useState("");
+
+  useEffect(() => {
+    setNoteContent(selectedAsset ? "" : "");
+  }, [selectedAsset?.id]);
 
   const noteMutation = useMutation({
     mutationFn: ({ assetId, content }: { assetId: number; content: string }) =>
       updateAssetNote(assetId, content),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["assets"] });
+    },
+    onError: (error) => {
+      addToast(`Failed to save note: ${error.message}`, "error");
     },
   });
 
@@ -29,6 +38,9 @@ export function AssetDetailPanel() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["assets"] });
     },
+    onError: (error) => {
+      addToast(`Failed to update rating: ${error.message}`, "error");
+    },
   });
 
   const statusMutation = useMutation({
@@ -37,6 +49,9 @@ export function AssetDetailPanel() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["assets"] });
     },
+    onError: (error) => {
+      addToast(`Failed to update status: ${error.message}`, "error");
+    },
   });
 
   const favoriteMutation = useMutation({
@@ -44,6 +59,9 @@ export function AssetDetailPanel() {
       setAssetFavorite(assetId, isFavorite),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["assets"] });
+    },
+    onError: (error) => {
+      addToast(`Failed to update favorite: ${error.message}`, "error");
     },
   });
 

--- a/src/features/asset-grid/AssetGrid.tsx
+++ b/src/features/asset-grid/AssetGrid.tsx
@@ -5,14 +5,17 @@ import { listAssets } from "@/shared/api/client";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import { AssetGridItem } from "./AssetGridItem";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/toast";
+import { useEffect } from "react";
 
 export function AssetGrid() {
   const parentRef = useRef<HTMLDivElement>(null);
   const selectedLibraryId = useAppStore((s) => s.selectedLibraryId);
   const thumbnailSize = useAppStore((s) => s.thumbnailSize);
   const searchQuery = useAppStore((s) => s.searchQuery);
+  const { addToast } = useToast();
 
-  const { data: assets = [], isLoading } = useQuery({
+  const { data: assets = [], isLoading, isError, error } = useQuery({
     queryKey: ["assets", selectedLibraryId, searchQuery],
     queryFn: () =>
       listAssets({
@@ -22,6 +25,12 @@ export function AssetGrid() {
       }),
     enabled: selectedLibraryId !== null,
   });
+
+  useEffect(() => {
+    if (isError && error) {
+      addToast(`Failed to load assets: ${error.message}`, "error");
+    }
+  }, [isError, error, addToast]);
 
   const columns = Math.max(1, Math.floor(window.innerWidth / (thumbnailSize + 20)));
 
@@ -50,6 +59,14 @@ export function AssetGrid() {
         {Array.from({ length: 12 }).map((_, i) => (
           <Skeleton key={i} className="w-full h-full" />
         ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        <p>Failed to load assets. Please try again.</p>
       </div>
     );
   }

--- a/src/features/libraries/AddLibraryDialog.tsx
+++ b/src/features/libraries/AddLibraryDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { FolderIcon } from "lucide-react";
+import { useToast } from "@/components/ui/toast";
 
 interface AddLibraryDialogProps {
   open: boolean;
@@ -23,6 +24,7 @@ export function AddLibraryDialog({ open, onOpenChange }: AddLibraryDialogProps) 
   const [path, setPath] = useState("");
   const addLibraryToStore = useAppStore((s) => s.addLibrary);
   const queryClient = useQueryClient();
+  const { addToast } = useToast();
 
   const mutation = useMutation({
     mutationFn: () => addLibrary(name, path),
@@ -32,6 +34,9 @@ export function AddLibraryDialog({ open, onOpenChange }: AddLibraryDialogProps) 
       setName("");
       setPath("");
       onOpenChange(false);
+    },
+    onError: (error) => {
+      addToast(`Failed to add library: ${error.message}`, "error");
     },
   });
 


### PR DESCRIPTION
## Purpose
- Add error handling for Tauri command failures so users see feedback when operations fail

## Changes
- Create ErrorToast component with ToastProvider and useToast hook
- Add isError/error handling to AssetGrid with toast notifications
- Add onError handlers to all mutations in AssetDetailPanel
- Add onError handler to AddLibraryDialog mutation
- Add error state display to Sidebar library list
- Wrap app in ToastProvider via QueryProvider

## Validation
- Run npm run typecheck - passes
- Run npm run build - passes
- Run npm run test - passes
- Error toasts appear on failed Tauri commands

## Impact
- All components using Tauri commands now show user-friendly error messages
- No breaking changes to existing functionality

Closes #55