### PR TITLE
fix: reset noteContent when selected asset changes

### DIFF
--- a/src/features/asset-detail/AssetDetailPanel.tsx
+++ b/src/features/asset-detail/AssetDetailPanel.tsx
@@ -18,7 +18,9 @@ export function AssetDetailPanel() {
   const [noteContent, setNoteContent] = useState("");
 
   useEffect(() => {
-    setNoteContent(selectedAsset ? "" : "");
+    if (selectedAsset) {
+      setNoteContent("");
+    }
   }, [selectedAsset?.id]);
 
   const noteMutation = useMutation({


### PR DESCRIPTION
## Purpose
- Fix bug where note content from previous asset persists when selecting a different asset

## Changes
- Add useEffect to reset noteContent when selectedAsset.id changes

## Validation
- Run npm run typecheck - passes
- Run npm run build - passes

## Impact
- AssetDetailPanel only

Closes #59