### PR TITLE
fix: show placeholder views for tags/posts/settings

### DIFF
--- a/src/app/layout/MainLayout.tsx
+++ b/src/app/layout/MainLayout.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/shared/hooks/useAppStore";
 
 export function MainLayout() {
   const isDetailPanelOpen = useAppStore((s) => s.isDetailPanelOpen);
+  const activeView = useAppStore((s) => s.activeView);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
   return (
@@ -18,7 +19,22 @@ export function MainLayout() {
       <div className="flex flex-col flex-1 overflow-hidden">
         <Toolbar />
         <main className="flex-1 overflow-auto">
-          <AssetGrid />
+          {activeView === "assets" && <AssetGrid />}
+          {activeView === "tags" && (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <p>Tags view coming soon</p>
+            </div>
+          )}
+          {activeView === "posts" && (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <p>Posts view coming soon</p>
+            </div>
+          )}
+          {activeView === "settings" && (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <p>Settings view coming soon</p>
+            </div>
+          )}
         </main>
       </div>
       {isDetailPanelOpen && <AssetDetailPanel />}


### PR DESCRIPTION
## Purpose
- Fix bug where clicking Tags/Posts/Settings in sidebar shows no content

## Changes
- Add conditional rendering in MainLayout based on activeView
- Show placeholder messages for unimplemented views

## Validation
- Run npm run typecheck - passes
- Run npm run build - passes

## Impact
- MainLayout component only

Closes #63