### PR TITLE
feat: add thumbnail support with loading states and error handling

### DIFF
--- a/src-tauri/src/infrastructure/mod.rs
+++ b/src-tauri/src/infrastructure/mod.rs
@@ -1,3 +1,5 @@
 pub mod file_scanner;
+pub mod thumbnail;
 
 pub use file_scanner::*;
+pub use thumbnail::*;

--- a/src-tauri/src/infrastructure/thumbnail.rs
+++ b/src-tauri/src/infrastructure/thumbnail.rs
@@ -1,0 +1,71 @@
+use anyhow::{Context, Result};
+use image::imageops::FilterType;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const THUMBNAIL_SIZE: u32 = 256;
+
+pub struct ThumbnailGenerator {
+    cache_dir: PathBuf,
+}
+
+impl ThumbnailGenerator {
+    pub fn new(cache_dir: PathBuf) -> Self {
+        fs::create_dir_all(&cache_dir).ok();
+        Self { cache_dir }
+    }
+
+    pub fn generate_thumbnail(
+        &self,
+        asset_id: i64,
+        source_path: &Path,
+        modified_at: &str,
+    ) -> Result<PathBuf> {
+        let cache_key = format!("{}_{}", asset_id, modified_at.replace([':', ' ', '-'], "_"));
+        let thumb_path = self.cache_dir.join(format!("{}.webp", cache_key));
+
+        if thumb_path.exists() {
+            return Ok(thumb_path);
+        }
+
+        let img = image::open(source_path)
+            .with_context(|| format!("Failed to open image: {:?}", source_path))?;
+
+        let thumbnail = img.resize(
+            THUMBNAIL_SIZE,
+            THUMBNAIL_SIZE,
+            FilterType::Lanczos3,
+        );
+
+        thumbnail
+            .save_with_format(&thumb_path, image::ImageFormat::WebP)
+            .with_context(|| format!("Failed to save thumbnail: {:?}", thumb_path))?;
+
+        Ok(thumb_path)
+    }
+
+    pub fn get_cached_thumbnail(&self, asset_id: i64, modified_at: &str) -> Option<PathBuf> {
+        let cache_key = format!("{}_{}", asset_id, modified_at.replace([':', ' ', '-'], "_"));
+        let thumb_path = self.cache_dir.join(format!("{}.webp", cache_key));
+
+        if thumb_path.exists() {
+            Some(thumb_path)
+        } else {
+            None
+        }
+    }
+
+    pub fn invalidate_thumbnail(&self, asset_id: i64) {
+        let pattern = format!("{}_", asset_id);
+        if let Ok(entries) = fs::read_dir(&self.cache_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with(&pattern) {
+                        fs::remove_file(path).ok();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/features/asset-detail/AssetDetailPanel.tsx
+++ b/src/features/asset-detail/AssetDetailPanel.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import { updateAssetNote, setAssetRating, setAssetStatus, setAssetFavorite } from "@/shared/api/client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { XIcon, StarIcon } from "lucide-react";
+import { XIcon, StarIcon, ImageIcon } from "lucide-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
 export function AssetDetailPanel() {
@@ -14,6 +14,14 @@ export function AssetDetailPanel() {
   const queryClient = useQueryClient();
 
   const [noteContent, setNoteContent] = useState("");
+  const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    if (selectedAsset) {
+      setNoteContent("");
+      setImageError(false);
+    }
+  }, [selectedAsset?.id]);
 
   const noteMutation = useMutation({
     mutationFn: ({ assetId, content }: { assetId: number; content: string }) =>
@@ -71,11 +79,18 @@ export function AssetDetailPanel() {
 
       <div className="flex-1 overflow-auto p-4 space-y-4">
         <div>
-          <img
-            src={convertFileSrc(selectedAsset.file_path)}
-            alt={selectedAsset.file_name}
-            className="w-full rounded-md bg-muted"
-          />
+          {imageError ? (
+            <div className="w-full aspect-square bg-muted rounded-md flex items-center justify-center">
+              <ImageIcon className="w-12 h-12 text-muted-foreground" />
+            </div>
+          ) : (
+            <img
+              src={convertFileSrc(selectedAsset.file_path)}
+              alt={selectedAsset.file_name}
+              className="w-full rounded-md bg-muted"
+              onError={() => setImageError(true)}
+            />
+          )}
         </div>
 
         <div className="space-y-1 text-sm">

--- a/src/features/asset-grid/AssetGridItem.tsx
+++ b/src/features/asset-grid/AssetGridItem.tsx
@@ -1,8 +1,9 @@
 import type { MouseEvent } from "react";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import type { Asset } from "@/entities/types";
-import { StarIcon } from "lucide-react";
+import { StarIcon, ImageIcon } from "lucide-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { useState } from "react";
 
 interface AssetGridItemProps {
   asset: Asset;
@@ -14,6 +15,8 @@ export function AssetGridItem({ asset, size }: AssetGridItemProps) {
   const toggleAssetSelection = useAppStore((s) => s.toggleAssetSelection);
   const setSelectedAsset = useAppStore((s) => s.setSelectedAsset);
   const isSelected = selectedAssetIds.includes(asset.id);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.ctrlKey || e.metaKey) {
@@ -23,7 +26,9 @@ export function AssetGridItem({ asset, size }: AssetGridItemProps) {
     }
   };
 
-  const thumbUrl = convertFileSrc(asset.file_path);
+  const thumbUrl = asset.thumb_status === "ready"
+    ? convertFileSrc(asset.file_path)
+    : null;
 
   return (
     <div
@@ -37,12 +42,28 @@ export function AssetGridItem({ asset, size }: AssetGridItemProps) {
       role="button"
       tabIndex={0}
     >
-      <img
-        src={thumbUrl}
-        alt={asset.file_name}
-        className="w-full h-full object-cover bg-muted"
-        loading="lazy"
-      />
+      {thumbUrl && !hasError ? (
+        <>
+          {isLoading && (
+            <div className="absolute inset-0 bg-muted animate-pulse" />
+          )}
+          <img
+            src={thumbUrl}
+            alt={asset.file_name}
+            className="w-full h-full object-cover bg-muted"
+            loading="lazy"
+            onLoad={() => setIsLoading(false)}
+            onError={() => {
+              setIsLoading(false);
+              setHasError(true);
+            }}
+          />
+        </>
+      ) : (
+        <div className="w-full h-full bg-muted flex items-center justify-center">
+          <ImageIcon className="w-8 h-8 text-muted-foreground" />
+        </div>
+      )}
       <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
       <div className="absolute bottom-0 left-0 right-0 p-1 text-white text-xs truncate opacity-0 group-hover:opacity-100 transition-opacity">
         {asset.file_name}


### PR DESCRIPTION
## Purpose
- Add thumbnail generation infrastructure and improve image loading UX

## Changes
### Backend (Rust)
- Add `ThumbnailGenerator` with disk cache
- Cache key based on asset_id + modified_at
- WebP format for efficient storage

### Frontend (React)
- Add loading skeleton for grid items
- Add error fallback for failed images
- Check thumb_status before loading
- Add image error handling in AssetDetailPanel

## Validation
- Run npm run typecheck - passes
- Run npm run build - passes

## Impact
- AssetGridItem and AssetDetailPanel components
- New Rust thumbnail infrastructure module

Closes #62