### PR TITLE
test: add unit tests for useAppStore and SearchInput

### DIFF
--- a/src/test/SearchInput.test.tsx
+++ b/src/test/SearchInput.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchInput } from "@/app/layout/SearchInput";
+
+const setSearchQueryMock = vi.fn();
+
+vi.mock("@/shared/hooks/useAppStore", () => ({
+  useAppStore: vi.fn((selector) => {
+    const state = {
+      searchQuery: "",
+      setSearchQuery: setSearchQueryMock,
+    };
+    return selector(state);
+  }),
+}));
+
+describe("SearchInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render search input", () => {
+    render(<SearchInput />);
+    const input = screen.getByPlaceholderText(/search assets/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should call setSearchQuery on change", () => {
+    render(<SearchInput />);
+    const input = screen.getByPlaceholderText(/search assets/i);
+    fireEvent.change(input, { target: { value: "test query" } });
+
+    expect(setSearchQueryMock).toHaveBeenCalledWith("test query");
+  });
+});

--- a/src/test/useAppStore.test.ts
+++ b/src/test/useAppStore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "@/shared/hooks/useAppStore";
+
+describe("useAppStore", () => {
+  beforeEach(() => {
+    const store = useAppStore.getState();
+    useAppStore.setState({
+      ...store,
+      selectedLibraryId: null,
+      selectedAssetIds: [],
+      selectedAsset: null,
+      searchQuery: "",
+      activeView: "assets",
+      viewMode: "grid",
+      thumbnailSize: 150,
+      isDetailPanelOpen: false,
+    });
+  });
+
+  it("should select a library", () => {
+    useAppStore.getState().selectLibrary(1);
+    expect(useAppStore.getState().selectedLibraryId).toBe(1);
+  });
+
+  it("should toggle asset selection", () => {
+    useAppStore.getState().toggleAssetSelection(1);
+    expect(useAppStore.getState().selectedAssetIds).toContain(1);
+
+    useAppStore.getState().toggleAssetSelection(1);
+    expect(useAppStore.getState().selectedAssetIds).not.toContain(1);
+  });
+
+  it("should set search query", () => {
+    useAppStore.getState().setSearchQuery("test");
+    expect(useAppStore.getState().searchQuery).toBe("test");
+  });
+
+  it("should toggle detail panel", () => {
+    useAppStore.getState().toggleDetailPanel();
+    expect(useAppStore.getState().isDetailPanelOpen).toBe(true);
+
+    useAppStore.getState().toggleDetailPanel();
+    expect(useAppStore.getState().isDetailPanelOpen).toBe(false);
+  });
+
+  it("should set active view", () => {
+    useAppStore.getState().setActiveView("tags");
+    expect(useAppStore.getState().activeView).toBe("tags");
+  });
+
+  it("should set thumbnail size", () => {
+    useAppStore.getState().setThumbnailSize(200);
+    expect(useAppStore.getState().thumbnailSize).toBe(200);
+  });
+});


### PR DESCRIPTION
## Purpose
- Add meaningful unit tests as required by Spec §15

## Changes
- Add `useAppStore.test.ts` with 6 test cases
- Add `SearchInput.test.tsx` with 2 test cases
- Total: 9 tests passing

## Validation
- Run npm run test - 9 tests pass

## Impact
- Test files only

Closes #64