### PR TITLE
Show images directly from folder without scan requirement

### DIFF
--- a/src-tauri/src/commands/folder.rs
+++ b/src-tauri/src/commands/folder.rs
@@ -1,0 +1,41 @@
+use crate::db::Database;
+use crate::domain::Library;
+use crate::infrastructure::scan_folder_quick;
+use std::sync::{Arc, Mutex};
+use tauri::State;
+
+#[tauri::command]
+pub fn list_libraries(state: State<'_, Arc<Mutex<Database>>>) -> Result<Vec<Library>, String> {
+    let db = state.lock().map_err(|e| e.to_string())?;
+    crate::application::LibraryService::new(&db)
+        .list_libraries()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_library_path(
+    state: State<'_, Arc<Mutex<Database>>>,
+    library_id: i64,
+) -> Result<String, String> {
+    let db = state.lock().map_err(|e| e.to_string())?;
+    let library = crate::application::LibraryService::new(&db)
+        .get_library(library_id)
+        .map_err(|e| e.to_string())?;
+    Ok(library.root_path)
+}
+
+#[tauri::command]
+pub fn list_assets_from_folder(
+    library_root_path: String,
+    offset: Option<i64>,
+    limit: Option<i64>,
+) -> Result<Vec<crate::infrastructure::QuickAsset>, String> {
+    let all = scan_folder_quick(&library_root_path);
+    let offset = offset.unwrap_or(0) as usize;
+    let limit = limit.unwrap_or(100) as usize;
+    let end = (offset + limit).min(all.len());
+    if offset > all.len() {
+        return Ok(Vec::new());
+    }
+    Ok(all[offset..end].to_vec())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,9 +3,11 @@ pub mod asset;
 pub mod tag;
 pub mod post;
 pub mod job;
+pub mod folder;
 
 pub use library::*;
 pub use asset::*;
 pub use tag::*;
 pub use post::*;
 pub use job::*;
+pub use folder::*;

--- a/src-tauri/src/infrastructure/mod.rs
+++ b/src-tauri/src/infrastructure/mod.rs
@@ -1,5 +1,7 @@
 pub mod file_scanner;
 pub mod thumbnail;
+pub mod quick_scanner;
 
 pub use file_scanner::*;
 pub use thumbnail::*;
+pub use quick_scanner::*;

--- a/src-tauri/src/infrastructure/quick_scanner.rs
+++ b/src-tauri/src/infrastructure/quick_scanner.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use walkdir::WalkDir;
+
+const IMAGE_EXTENSIONS: &[&str] = &[
+    "jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "ico", "svg", "avif", "apng",
+];
+
+#[derive(serde::Serialize)]
+pub struct QuickAsset {
+    pub id: i64,
+    pub file_path: String,
+    pub file_name: String,
+    pub folder_path: String,
+    pub extension: String,
+    pub file_size: i64,
+    pub modified_at: String,
+}
+
+pub fn scan_folder_quick(root_path: &str) -> Vec<QuickAsset> {
+    let root = Path::new(root_path);
+    if !root.exists() || !root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut assets = Vec::new();
+    let mut id: i64 = 1;
+
+    for entry in WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let extension = match path.extension().and_then(|s| s.to_str()) {
+            Some(ext) => ext.to_lowercase(),
+            None => continue,
+        };
+
+        if !IMAGE_EXTENSIONS.contains(&extension.as_str()) {
+            continue;
+        }
+
+        let file_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+
+        let file_path = match path.to_str() {
+            Some(p) => p.to_string(),
+            None => continue,
+        };
+
+        let folder_path = path
+            .parent()
+            .and_then(|p| p.to_str())
+            .unwrap_or(root_path)
+            .to_string();
+
+        let file_size = path.metadata().map(|m| m.len() as i64).unwrap_or(0);
+        let modified_at = path
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(|t| {
+                let datetime: chrono::DateTime<chrono::Utc> = t.into();
+                datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+            })
+            .unwrap_or_default();
+
+        assets.push(QuickAsset {
+            id,
+            file_path,
+            file_name,
+            folder_path,
+            extension,
+            file_size,
+            modified_at,
+        });
+        id += 1;
+    }
+
+    assets
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,8 @@ pub fn run() {
             commands::attach_assets_to_post,
             commands::get_post_assets,
             commands::cancel_job,
+            commands::get_library_path,
+            commands::list_assets_from_folder,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/features/asset-grid/AssetGrid.tsx
+++ b/src/features/asset-grid/AssetGrid.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useRef, useState, useEffect, useCallback } from "react";
-import { listAssets } from "@/shared/api/client";
+import { getLibraryPath, listAssetsFromFolder } from "@/shared/api/client";
 import { useAppStore } from "@/shared/hooks/useAppStore";
 import { AssetGridItem } from "./AssetGridItem";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -13,7 +13,6 @@ export function AssetGrid() {
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedLibraryId = useAppStore((s) => s.selectedLibraryId);
   const thumbnailSize = useAppStore((s) => s.thumbnailSize);
-  const searchQuery = useAppStore((s) => s.searchQuery);
   const { addToast } = useToast();
   const [containerWidth, setContainerWidth] = useState(0);
 
@@ -23,41 +22,29 @@ export function AssetGrid() {
         setContainerWidth(containerRef.current.clientWidth);
       }
     };
-
     updateWidth();
-
     const observer = new ResizeObserver(updateWidth);
     if (containerRef.current) {
       observer.observe(containerRef.current);
     }
-
     return () => observer.disconnect();
   }, []);
 
-  const {
-    data,
-    isLoading,
-    isError,
-    error,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["assets", selectedLibraryId, searchQuery],
-    queryFn: ({ pageParam = 0 }) =>
-      listAssets({
-        library_id: selectedLibraryId ?? undefined,
-        search: searchQuery || undefined,
-        limit: PAGE_SIZE,
-        offset: pageParam as number,
-      }),
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.length < PAGE_SIZE) return undefined;
-      return allPages.length * PAGE_SIZE;
-    },
-    initialPageParam: 0,
-    enabled: selectedLibraryId !== null,
-  });
+  const { data, isLoading, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["folder-assets", selectedLibraryId],
+      queryFn: async ({ pageParam = 0 }) => {
+        if (!selectedLibraryId) return [];
+        const rootPath = await getLibraryPath(selectedLibraryId);
+        return listAssetsFromFolder(rootPath, pageParam as number, PAGE_SIZE);
+      },
+      getNextPageParam: (lastPage, allPages) => {
+        if (lastPage.length < PAGE_SIZE) return undefined;
+        return allPages.length * PAGE_SIZE;
+      },
+      initialPageParam: 0,
+      enabled: selectedLibraryId !== null,
+    });
 
   const assets = data?.pages.flat() ?? [];
 
@@ -130,7 +117,7 @@ export function AssetGrid() {
   if (assets.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground">
-        <p>No assets found. Try scanning the library.</p>
+        <p>No images found in this folder.</p>
       </div>
     );
   }
@@ -167,7 +154,33 @@ export function AssetGrid() {
                 }}
               >
                 {rowAssets.map((asset) => (
-                  <AssetGridItem key={asset.id} asset={asset} size={thumbnailSize} />
+                  <AssetGridItem
+                    key={asset.id}
+                    asset={{
+                      id: asset.id,
+                      library_id: 0,
+                      folder_path: asset.folder_path,
+                      file_name: asset.file_name,
+                      file_path: asset.file_path,
+                      extension: asset.extension,
+                      file_size: asset.file_size,
+                      created_at_fs: null,
+                      modified_at_fs: asset.modified_at,
+                      width: null,
+                      height: null,
+                      mime_type: null,
+                      hash_blake3: null,
+                      thumb_status: "none",
+                      thumb_path: null,
+                      rating: 0,
+                      status_label: "unorganized",
+                      is_favorite: false,
+                      color_label: null,
+                      indexed_at: "",
+                      updated_at: "",
+                    }}
+                    size={thumbnailSize}
+                  />
                 ))}
               </div>
             </div>

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -64,6 +64,30 @@ export async function listAssets(query: AssetQuery = {}) {
   });
 }
 
+export async function getLibraryPath(libraryId: number) {
+  return invoke<string>("get_library_path", { libraryId });
+}
+
+export async function listAssetsFromFolder(
+  libraryRootPath: string,
+  offset: number,
+  limit: number
+) {
+  return invoke<Array<{
+    id: number;
+    file_path: string;
+    file_name: string;
+    folder_path: string;
+    extension: string;
+    file_size: number;
+    modified_at: string;
+  }>>("list_assets_from_folder", {
+    libraryRootPath,
+    offset,
+    limit,
+  });
+}
+
 export async function getAssetDetail(assetId: number) {
   return invoke<Asset>("get_asset_detail", { assetId });
 }


### PR DESCRIPTION
## Change
- Select folder → images appear immediately
- No scan button needed
- No database registration required
- Reads files directly from filesystem on demand

## How it works
- New `quick_scanner` reads folder recursively using WalkDir
- `list_assets_from_folder` command returns image list directly
- AssetGrid uses infinite query to load pages of 100 images
- Virtual scrolling for performance with large folders

Closes #85