### PR TITLE
fix: correct YAML indentation in workflow files

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,33 +39,33 @@ jobs:
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
-  - name: Build Windows app (installer)
-      run: wails build -platform windows/amd64
-      env:
-        CGO_ENABLED: "0"
+      - name: Build Windows app (installer)
+        run: wails build -platform windows/amd64
+        env:
+          CGO_ENABLED: "0"
 
-    - name: Build Windows portable
-      run: wails build -platform windows/amd64 -ldflags "-H windowsgui" -o Lumine-portable.exe
-      env:
-        CGO_ENABLED: "0"
+      - name: Build Windows portable
+        run: wails build -platform windows/amd64 -ldflags "-H windowsgui" -o Lumine-portable.exe
+        env:
+          CGO_ENABLED: "0"
 
-    - name: Upload exe artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: lumine-windows
-        path: build/bin/Lumine.exe
+      - name: Upload exe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumine-windows
+          path: build/bin/Lumine.exe
 
-    - name: Package portable version
-      run: Compress-Archive -Path build/bin/Lumine-portable.exe -DestinationPath build/bin/Lumine-portable.zip
+      - name: Package portable version
+        run: Compress-Archive -Path build/bin/Lumine-portable.exe -DestinationPath build/bin/Lumine-portable.zip
 
-    - name: Upload portable artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: lumine-windows-portable
-        path: build/bin/Lumine-portable.zip
+      - name: Upload portable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumine-windows-portable
+          path: build/bin/Lumine-portable.zip
 
-    - name: Upload full bundle
-      uses: actions/upload-artifact@v4
-      with:
-        name: lumine-windows-bundle
-        path: build/bin/*
+      - name: Upload full bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumine-windows-bundle
+          path: build/bin/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,17 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-    - name: Lint
-      working-directory: frontend
-      run: npx eslint src --max-warnings 0
+      - name: Lint
+        working-directory: frontend
+        run: npx eslint src --max-warnings 0
 
       - name: Typecheck
         working-directory: frontend
         run: npx tsc --noEmit
 
-    - name: Unit tests
-      working-directory: frontend
-      run: npx vitest run
+      - name: Unit tests
+        working-directory: frontend
+        run: npx vitest run
 
       - name: Build
         working-directory: frontend

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,6 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps
 
-    - name: Run e2e
-      working-directory: frontend
-      run: npx playwright test
+      - name: Run e2e
+        working-directory: frontend
+        run: npx playwright test


### PR DESCRIPTION
## Purpose
All three workflow files (ci.yml, build-windows.yml, e2e.yml) have YAML syntax errors that prevent GitHub Actions from parsing them, causing all CI to fail.

## Changes
Rewrite all workflow files with consistent 2-space indentation. The `steps:` list items and their sub-properties now use proper YAML nesting.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open(...))"` passes for all 3 files
- Local `go test`, `go build`, `go vet`, `npx tsc --noEmit`, `npx vitest run` all pass

## Impact
CI/CD pipelines only — no application code changed

Closes #119