### PR TITLE
fix: 子フォルダーのアセットが表示されない問題を修正

### DIFF
--- a/frontend/src/components/AssetGrid.tsx
+++ b/frontend/src/components/AssetGrid.tsx
@@ -42,6 +42,7 @@ export function AssetGrid({ onSelectAsset, onAssetsLoaded }: AssetGridProps) {
         libraryId: state.selectedLibraryId ?? 0,
         search: search || undefined,
         folderPath: folderPath || undefined,
+        recurse: !!folderPath,
         sortBy: state.sortBy || undefined,
         sortDesc: state.sortDesc,
         statusLabel: state.filterStatusLabel || undefined,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -102,44 +102,46 @@ export namespace commands {
 		    return a;
 		}
 	}
-	export class AssetListRequest {
-	    libraryId: number;
-	    folderPath?: string;
-	    search?: string;
-	    rating?: number;
-	    statusLabel?: string;
-	    isFavorite?: boolean;
-	    tagIds?: number[];
-	    hasNote?: boolean;
-	    extension?: string;
-	    colorLabel?: string;
-	    sortBy?: string;
-	    sortDesc?: boolean;
-	    offset: number;
-	    limit: number;
-	
-	    static createFrom(source: any = {}) {
-	        return new AssetListRequest(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.libraryId = source["libraryId"];
-	        this.folderPath = source["folderPath"];
-	        this.search = source["search"];
-	        this.rating = source["rating"];
-	        this.statusLabel = source["statusLabel"];
-	        this.isFavorite = source["isFavorite"];
-	        this.tagIds = source["tagIds"];
-	        this.hasNote = source["hasNote"];
-	        this.extension = source["extension"];
-	        this.colorLabel = source["colorLabel"];
-	        this.sortBy = source["sortBy"];
-	        this.sortDesc = source["sortDesc"];
-	        this.offset = source["offset"];
-	        this.limit = source["limit"];
-	    }
-	}
+export class AssetListRequest {
+  libraryId: number;
+  folderPath?: string;
+  recurse?: boolean;
+  search?: string;
+  rating?: number;
+  statusLabel?: string;
+  isFavorite?: boolean;
+  tagIds?: number[];
+  hasNote?: boolean;
+  extension?: string;
+  colorLabel?: string;
+  sortBy?: string;
+  sortDesc?: boolean;
+  offset: number;
+  limit: number;
+
+  static createFrom(source: any = {}) {
+    return new AssetListRequest(source);
+  }
+
+  constructor(source: any = {}) {
+    if ('string' === typeof source) source = JSON.parse(source);
+    this.libraryId = source["libraryId"];
+    this.folderPath = source["folderPath"];
+    this.recurse = source["recurse"];
+    this.search = source["search"];
+    this.rating = source["rating"];
+    this.statusLabel = source["statusLabel"];
+    this.isFavorite = source["isFavorite"];
+    this.tagIds = source["tagIds"];
+    this.hasNote = source["hasNote"];
+    this.extension = source["extension"];
+    this.colorLabel = source["colorLabel"];
+    this.sortBy = source["sortBy"];
+    this.sortDesc = source["sortDesc"];
+    this.offset = source["offset"];
+    this.limit = source["limit"];
+  }
+}
 	export class AssetListResponse {
 	    assets: AssetDTO[];
 	    totalCount: number;

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -269,9 +269,10 @@ func toAssetDTO(a *domain.Asset) AssetDTO {
 }
 
 type AssetListRequest struct {
-	LibraryID   int64  `json:"libraryId"`
-	FolderPath  string `json:"folderPath,omitempty"`
-	Search      string `json:"search,omitempty"`
+	LibraryID  int64  `json:"libraryId"`
+	FolderPath string `json:"folderPath,omitempty"`
+	Recurse    bool   `json:"recurse,omitempty"`
+	Search     string `json:"search,omitempty"`
 	Rating      int    `json:"rating,omitempty"`
 	StatusLabel string `json:"statusLabel,omitempty"`
 	IsFavorite  *bool  `json:"isFavorite,omitempty"`
@@ -292,9 +293,10 @@ type AssetListResponse struct {
 
 func (c *AppCommands) ListAssets(req AssetListRequest) *AssetListResponse {
 	result, err := c.assetRepo.List(db.AssetQuery{
-		LibraryID:   req.LibraryID,
-		FolderPath:  req.FolderPath,
-		Search:      req.Search,
+		LibraryID:  req.LibraryID,
+		FolderPath: req.FolderPath,
+		Recurse:    req.Recurse,
+		Search:     req.Search,
 		Rating:      req.Rating,
 		StatusLabel: req.StatusLabel,
 		IsFavorite:  req.IsFavorite,

--- a/internal/infrastructure/db/asset_repo.go
+++ b/internal/infrastructure/db/asset_repo.go
@@ -16,9 +16,10 @@ func NewAssetRepo(db *DB) *AssetRepo {
 }
 
 type AssetQuery struct {
-	LibraryID   int64
-	FolderPath  string
-	Search      string
+	LibraryID  int64
+	FolderPath string
+	Recurse    bool
+	Search     string
 	Rating      int
 	StatusLabel string
 	IsFavorite  *bool
@@ -50,8 +51,13 @@ func (r *AssetRepo) List(q AssetQuery) (*AssetListResult, error) {
 		args = append(args, q.LibraryID)
 	}
 	if q.FolderPath != "" {
-		where += " AND a.folder_path = ?"
-		args = append(args, q.FolderPath)
+		if q.Recurse {
+			where += " AND (a.folder_path = ? OR a.folder_path LIKE ? OR a.folder_path LIKE ?)"
+			args = append(args, q.FolderPath, q.FolderPath+"/%", q.FolderPath+"\\%")
+		} else {
+			where += " AND a.folder_path = ?"
+			args = append(args, q.FolderPath)
+		}
 	}
 	if q.Search != "" {
 		where += " AND (a.file_name LIKE ? OR EXISTS (SELECT 1 FROM asset_notes n WHERE n.asset_id = a.id AND n.content LIKE ?))"


### PR DESCRIPTION
## Purpose
フォルダーツリーでフォルダーを選択した際、子階層（サブフォルダー）内の画像が表示されないバグを修正する

## Superseded
この修正は PR #133 `rewrite: Lumine Viewer Core を再構築し日本語UI/UXを刷新` に取り込まれ、`develop` へマージ済みです。

#133 側ではフォルダー再帰表示に加え、Viewer Core・起動・画像読み込み・DB・日本語UI/UXまで統合して検証しているため、この PR は重複として close します。

Closes #131