### PR TITLE
feat: 画像拡大モーダルと投稿記録UXを強化

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -227,7 +227,7 @@ export default function App() {
             <ToolbarV2 />
             <div className="app-main-region relative flex flex-1 min-h-0 min-w-0">
               <div className="flex-1 min-w-0 flex"><ViewerGridV2 onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} /></div>
-              {state.detailOpen && state.detailAsset && <AssetDetailPanel assetId={state.detailAsset.id} onClose={handleCloseDetail} />}
+              {state.detailOpen && state.detailAsset && <AssetDetailPanel asset={state.detailAsset} onClose={handleCloseDetail} />}
             </div>
             {state.selectedAssets.size > 1 && (
               <BulkActionsBar

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Sidebar, Toolbar, WelcomeScreen } from "./components/Sidebar";
+import { SidebarV2, ToolbarV2, WelcomeScreenV2 } from "./components/NavigationV2";
 import { ViewerGridV2 } from "./components/ViewerGridV2";
 import { AssetDetailPanel } from "./components/AssetDetailPanel";
 import { PostRecordModal } from "./components/PostRecordModal";
@@ -92,7 +92,6 @@ export default function App() {
       const thumbnailSize = typeof savedThumbnailSize === "number" && savedThumbnailSize >= 80 && savedThumbnailSize <= 420
         ? savedThumbnailSize
         : defaultState.thumbnailSize;
-
       setState((current) => ({
         ...current,
         libraries,
@@ -119,16 +118,8 @@ export default function App() {
       const name = path.split(/[/\\]/).pop() || "画像フォルダー";
       const library = await addLibrary(name, path);
       if (!library) throw new Error("ライブラリの登録に失敗しました");
-
       const libraries = await listLibraries();
-      setState((current) => ({
-        ...current,
-        libraries,
-        selectedLibraryId: library.id,
-        selectedFolderPath: "",
-        searchQuery: "",
-      }));
-
+      setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "" }));
       await scanLibrary(library.id);
       const refreshedLibraries = await listLibraries();
       setState((current) => ({ ...current, libraries: refreshedLibraries }));
@@ -149,7 +140,6 @@ export default function App() {
       let selection: Set<number>;
       let lastIndex: number | null = null;
       const currentIndex = current.allAssetIds.indexOf(asset.id);
-
       if (range && current.lastSelectedIndex !== null && currentIndex >= 0) {
         const start = Math.min(current.lastSelectedIndex, currentIndex);
         const end = Math.max(current.lastSelectedIndex, currentIndex);
@@ -158,28 +148,17 @@ export default function App() {
         lastIndex = currentIndex;
       } else if (multi) {
         selection = new Set(current.selectedAssets);
-        if (selection.has(asset.id)) selection.delete(asset.id);
-        else selection.add(asset.id);
+        if (selection.has(asset.id)) selection.delete(asset.id); else selection.add(asset.id);
         lastIndex = currentIndex >= 0 ? currentIndex : current.lastSelectedIndex;
       } else {
         selection = new Set([asset.id]);
         lastIndex = currentIndex >= 0 ? currentIndex : null;
       }
-
-      return {
-        ...current,
-        selectedAssets: selection,
-        lastSelectedIndex: lastIndex,
-        detailAsset: asset,
-        detailOpen: true,
-      };
+      return { ...current, selectedAssets: selection, lastSelectedIndex: lastIndex, detailAsset: asset, detailOpen: true };
     });
   }, []);
 
-  const handleCloseDetail = useCallback(() => {
-    setState((current) => ({ ...current, detailOpen: false, detailAsset: null }));
-  }, []);
-
+  const handleCloseDetail = useCallback(() => setState((current) => ({ ...current, detailOpen: false, detailAsset: null })), []);
   const handleAssetsLoaded = useCallback((ids: number[]) => {
     setState((current) => {
       if (current.allAssetIds.length === ids.length && current.allAssetIds.every((id, index) => id === ids[index])) return current;
@@ -190,41 +169,36 @@ export default function App() {
   const selectedIDs = Array.from(state.selectedAssets);
 
   const handleBulkRate = useCallback(async (rating: number) => {
-    if (state.selectedAssets.size === 0) return;
+    if (!state.selectedAssets.size) return;
     await bulkUpdateRating(Array.from(state.selectedAssets), rating);
     await queryClient.invalidateQueries({ queryKey: ["assets"] });
   }, [state.selectedAssets]);
 
   const handleBulkStatus = useCallback(async (status: string) => {
-    if (state.selectedAssets.size === 0) return;
+    if (!state.selectedAssets.size) return;
     await bulkUpdateStatus(Array.from(state.selectedAssets), status);
     await queryClient.invalidateQueries({ queryKey: ["assets"] });
   }, [state.selectedAssets]);
 
   const handleBulkFavorite = useCallback(async (favorite: boolean) => {
-    if (state.selectedAssets.size === 0) return;
+    if (!state.selectedAssets.size) return;
     await bulkUpdateFavorite(Array.from(state.selectedAssets), favorite);
     await queryClient.invalidateQueries({ queryKey: ["assets"] });
   }, [state.selectedAssets]);
 
   const handleBulkColorLabel = useCallback(async (label: string) => {
-    if (state.selectedAssets.size === 0) return;
+    if (!state.selectedAssets.size) return;
     await bulkUpdateColorLabel(Array.from(state.selectedAssets), label);
     await queryClient.invalidateQueries({ queryKey: ["assets"] });
   }, [state.selectedAssets]);
 
   const handleBulkDelete = useCallback(async () => {
     const ids = Array.from(state.selectedAssets);
-    if (ids.length === 0) return;
+    if (!ids.length) return;
     if (!confirm(`選択した${ids.length}件をLumineの一覧から削除します。\n元の画像ファイルは削除されません。\n\n続行しますか？`)) return;
     try {
       await bulkDeleteAssets(ids);
-      setState((current) => ({
-        ...current,
-        selectedAssets: new Set<number>(),
-        detailOpen: false,
-        detailAsset: null,
-      }));
+      setState((current) => ({ ...current, selectedAssets: new Set<number>(), detailOpen: false, detailAsset: null }));
       await queryClient.invalidateQueries({ queryKey: ["assets"] });
     } catch (error) {
       console.error("bulk delete failed:", error);
@@ -233,52 +207,28 @@ export default function App() {
   }, [state.selectedAssets]);
 
   if (booting) {
-    return (
-      <div className="h-screen bg-background text-foreground flex items-center justify-center">
-        <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
-          <div className="w-6 h-6 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" />
-          <span>Lumineを起動しています…</span>
-        </div>
-      </div>
-    );
+    return <div className="h-screen bg-background text-foreground flex items-center justify-center"><div className="flex flex-col items-center gap-3 text-sm text-muted-foreground"><div className="w-6 h-6 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" /><span>Lumineを起動しています…</span></div></div>;
   }
 
   if (bootstrapError) {
-    return (
-      <div className="h-screen bg-background text-foreground flex items-center justify-center p-8">
-        <div className="max-w-lg text-center space-y-4 rounded-2xl border border-border bg-card p-8">
-          <h1 className="text-lg font-semibold">ライブラリ情報を読み込めませんでした</h1>
-          <p className="text-sm text-muted-foreground">Lumineのデータベースを開く際にエラーが発生しました。</p>
-          <p className="text-xs text-muted-foreground/70 break-words font-mono">{bootstrapError}</p>
-          <button onClick={() => void loadBootstrap()} className="ui-primary-button">再試行</button>
-        </div>
-      </div>
-    );
+    return <div className="h-screen bg-background text-foreground flex items-center justify-center p-8"><div className="max-w-lg text-center space-y-4 rounded-2xl border border-border bg-card p-8"><h1 className="text-lg font-semibold">ライブラリ情報を読み込めませんでした</h1><p className="text-sm text-muted-foreground">Lumineのデータベースを開く際にエラーが発生しました。</p><p className="text-xs text-muted-foreground/70 break-words font-mono">{bootstrapError}</p><button onClick={() => void loadBootstrap()} className="ui-primary-button">再試行</button></div></div>;
   }
 
   if (state.libraries.length === 0 && !state.selectedLibraryId) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <WelcomeScreen onSelectFolder={handleSelectFolder} busy={addingLibrary} />
-      </QueryClientProvider>
-    );
+    return <QueryClientProvider client={queryClient}><WelcomeScreenV2 onSelectFolder={handleSelectFolder} busy={addingLibrary} /></QueryClientProvider>;
   }
 
   return (
     <QueryClientProvider client={queryClient}>
       <AppContext.Provider value={{ state, setState }}>
         <div className="app-shell flex h-screen bg-background text-foreground overflow-hidden">
-          {state.sidebarOpen && <Sidebar />}
-
+          {state.sidebarOpen && <SidebarV2 />}
           <div className="flex flex-col flex-1 min-w-0">
-            <Toolbar />
+            <ToolbarV2 />
             <div className="app-main-region relative flex flex-1 min-h-0 min-w-0">
-              <div className="flex-1 min-w-0 flex">
-                <ViewerGridV2 onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} />
-              </div>
+              <div className="flex-1 min-w-0 flex"><ViewerGridV2 onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} /></div>
               {state.detailOpen && state.detailAsset && <AssetDetailPanel assetId={state.detailAsset.id} onClose={handleCloseDetail} />}
             </div>
-
             {state.selectedAssets.size > 1 && (
               <BulkActionsBar
                 count={state.selectedAssets.size}
@@ -293,29 +243,13 @@ export default function App() {
             )}
           </div>
         </div>
-
-        {bulkPostRecordOpen && selectedIDs.length > 0 && (
-          <PostRecordModal
-            assetIds={selectedIDs}
-            defaultTitle={`${selectedIDs.length}件の画像`}
-            onClose={() => setBulkPostRecordOpen(false)}
-          />
-        )}
+        {bulkPostRecordOpen && selectedIDs.length > 0 && <PostRecordModal assetIds={selectedIDs} defaultTitle={`${selectedIDs.length}件の画像`} onClose={() => setBulkPostRecordOpen(false)} />}
       </AppContext.Provider>
     </QueryClientProvider>
   );
 }
 
-export function BulkActionsBar({
-  count,
-  onRate,
-  onStatus,
-  onFavorite,
-  onColorLabel,
-  onPostRecord,
-  onDelete,
-  onClear,
-}: {
+export function BulkActionsBar({ count, onRate, onStatus, onFavorite, onColorLabel, onPostRecord, onDelete, onClear }: {
   count: number;
   onRate: (rating: number) => void;
   onStatus: (status: string) => void;
@@ -331,35 +265,21 @@ export function BulkActionsBar({
     { value: "candidate", label: "候補" },
     { value: "published", label: "公開済み" },
   ];
-
   return (
     <div className="min-h-14 flex items-center gap-2 px-3 py-2 border-t border-border bg-card shadow-[0_-8px_24px_rgba(0,0,0,0.15)] flex-shrink-0 overflow-x-auto">
       <span className="text-xs font-semibold whitespace-nowrap">{count}件を選択中</span>
       <div className="h-5 w-px bg-border" />
-
-      <div className="flex items-center gap-1 whitespace-nowrap">
-        <span className="text-[11px] text-muted-foreground mr-1">評価</span>
-        {[1, 2, 3, 4, 5].map((rating) => <button key={rating} onClick={() => onRate(rating)} className="w-8 h-8 rounded-lg hover:bg-accent text-yellow-400" title={`評価を${rating}に設定`}>★</button>)}
-      </div>
-
+      <div className="flex items-center gap-1 whitespace-nowrap"><span className="text-[11px] text-muted-foreground mr-1">評価</span>{[1,2,3,4,5].map((rating) => <button key={rating} onClick={() => onRate(rating)} className="w-8 h-8 rounded-lg hover:bg-accent text-yellow-400" title={`評価を${rating}に設定`}>★</button>)}</div>
       <div className="h-5 w-px bg-border" />
-      <div className="flex items-center gap-1 whitespace-nowrap">
-        <span className="text-[11px] text-muted-foreground mr-1">状態</span>
-        {statuses.map((status) => <button key={status.value} onClick={() => onStatus(status.value)} className="ui-secondary-button">{status.label}</button>)}
-      </div>
-
+      <div className="flex items-center gap-1 whitespace-nowrap"><span className="text-[11px] text-muted-foreground mr-1">状態</span>{statuses.map((status) => <button key={status.value} onClick={() => onStatus(status.value)} className="ui-secondary-button">{status.label}</button>)}</div>
       <div className="h-5 w-px bg-border" />
-      <button onClick={() => onFavorite(true)} className="ui-secondary-button whitespace-nowrap">★ お気に入り</button>
-      <button onClick={onPostRecord} className="ui-primary-button whitespace-nowrap">＋ 投稿記録</button>
+      <div className="flex items-center gap-1 whitespace-nowrap"><span className="text-[11px] text-muted-foreground mr-1">色</span>{["","red","orange","yellow","green","blue","purple"].map((label) => <button key={label || "none"} onClick={() => onColorLabel(label)} className="w-5 h-5 rounded-full border border-border" style={{ backgroundColor: label || "transparent" }} title={label || "なし"} />)}</div>
+      <div className="h-5 w-px bg-border" />
+      <button onClick={() => onFavorite(true)} className="ui-secondary-button">★ お気に入り</button>
+      <button onClick={onPostRecord} className="ui-primary-button">＋ 投稿記録</button>
       <button onClick={onDelete} className="h-8 px-3 rounded-lg bg-destructive text-destructive-foreground text-[11px] font-medium whitespace-nowrap">一覧から削除</button>
       <div className="flex-1 min-w-3" />
-      <button onClick={onClear} className="ui-secondary-button whitespace-nowrap">選択解除</button>
-
-      <div className="hidden">
-        {["", "red", "orange", "yellow", "green", "blue", "purple"].map((label) => (
-          <button key={label || "none"} onClick={() => onColorLabel(label)}>{label || "none"}</button>
-        ))}
-      </div>
+      <button onClick={onClear} className="ui-secondary-button">選択解除</button>
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Sidebar, Toolbar, WelcomeScreen } from "./components/Sidebar";
-import { ViewerGrid } from "./components/ViewerGrid";
+import { ViewerGridV2 } from "./components/ViewerGridV2";
 import { AssetDetailPanel } from "./components/AssetDetailPanel";
+import { PostRecordModal } from "./components/PostRecordModal";
 import type { AssetDTO, LibraryDTO } from "./api/client";
 import {
   addLibrary,
@@ -78,21 +79,19 @@ export default function App() {
   const [booting, setBooting] = useState(true);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [addingLibrary, setAddingLibrary] = useState(false);
+  const [bulkPostRecordOpen, setBulkPostRecordOpen] = useState(false);
 
   const loadBootstrap = useCallback(async () => {
     setBooting(true);
     setBootstrapError(null);
     try {
       const bootstrap = (await getAppBootstrap()) as unknown as BootstrapPayload;
-      const libraries = Array.isArray(bootstrap?.libraries)
-        ? bootstrap.libraries
-        : await listLibraries();
+      const libraries = Array.isArray(bootstrap?.libraries) ? bootstrap.libraries : await listLibraries();
       const preferredLibrary = libraries.find((library) => library.isEnabled) ?? libraries[0];
       const savedThumbnailSize = bootstrap?.settings?.thumbnailSize;
-      const thumbnailSize =
-        typeof savedThumbnailSize === "number" && savedThumbnailSize >= 80 && savedThumbnailSize <= 420
-          ? savedThumbnailSize
-          : defaultState.thumbnailSize;
+      const thumbnailSize = typeof savedThumbnailSize === "number" && savedThumbnailSize >= 80 && savedThumbnailSize <= 420
+        ? savedThumbnailSize
+        : defaultState.thumbnailSize;
 
       setState((current) => ({
         ...current,
@@ -109,9 +108,7 @@ export default function App() {
     }
   }, []);
 
-  useEffect(() => {
-    void loadBootstrap();
-  }, [loadBootstrap]);
+  useEffect(() => { void loadBootstrap(); }, [loadBootstrap]);
 
   const handleSelectFolder = useCallback(async () => {
     if (addingLibrary) return;
@@ -147,42 +144,37 @@ export default function App() {
     }
   }, [addingLibrary]);
 
-  const handleSelectAsset = useCallback(
-    (asset: AssetDTO, multi: boolean, range: boolean) => {
-      setState((current) => {
-        let selection: Set<number>;
-        let lastIndex: number | null = null;
-        const currentIndex = current.allAssetIds.indexOf(asset.id);
+  const handleSelectAsset = useCallback((asset: AssetDTO, multi: boolean, range: boolean) => {
+    setState((current) => {
+      let selection: Set<number>;
+      let lastIndex: number | null = null;
+      const currentIndex = current.allAssetIds.indexOf(asset.id);
 
-        if (range && current.lastSelectedIndex !== null && currentIndex >= 0) {
-          const start = Math.min(current.lastSelectedIndex, currentIndex);
-          const end = Math.max(current.lastSelectedIndex, currentIndex);
-          const rangeIds = current.allAssetIds.slice(start, end + 1);
-          selection = multi
-            ? new Set([...current.selectedAssets, ...rangeIds])
-            : new Set(rangeIds);
-          lastIndex = currentIndex;
-        } else if (multi) {
-          selection = new Set(current.selectedAssets);
-          if (selection.has(asset.id)) selection.delete(asset.id);
-          else selection.add(asset.id);
-          lastIndex = currentIndex >= 0 ? currentIndex : current.lastSelectedIndex;
-        } else {
-          selection = new Set([asset.id]);
-          lastIndex = currentIndex >= 0 ? currentIndex : null;
-        }
+      if (range && current.lastSelectedIndex !== null && currentIndex >= 0) {
+        const start = Math.min(current.lastSelectedIndex, currentIndex);
+        const end = Math.max(current.lastSelectedIndex, currentIndex);
+        const rangeIds = current.allAssetIds.slice(start, end + 1);
+        selection = multi ? new Set([...current.selectedAssets, ...rangeIds]) : new Set(rangeIds);
+        lastIndex = currentIndex;
+      } else if (multi) {
+        selection = new Set(current.selectedAssets);
+        if (selection.has(asset.id)) selection.delete(asset.id);
+        else selection.add(asset.id);
+        lastIndex = currentIndex >= 0 ? currentIndex : current.lastSelectedIndex;
+      } else {
+        selection = new Set([asset.id]);
+        lastIndex = currentIndex >= 0 ? currentIndex : null;
+      }
 
-        return {
-          ...current,
-          selectedAssets: selection,
-          lastSelectedIndex: lastIndex,
-          detailAsset: asset,
-          detailOpen: true,
-        };
-      });
-    },
-    []
-  );
+      return {
+        ...current,
+        selectedAssets: selection,
+        lastSelectedIndex: lastIndex,
+        detailAsset: asset,
+        detailOpen: true,
+      };
+    });
+  }, []);
 
   const handleCloseDetail = useCallback(() => {
     setState((current) => ({ ...current, detailOpen: false, detailAsset: null }));
@@ -190,15 +182,12 @@ export default function App() {
 
   const handleAssetsLoaded = useCallback((ids: number[]) => {
     setState((current) => {
-      if (
-        current.allAssetIds.length === ids.length &&
-        current.allAssetIds.every((id, index) => id === ids[index])
-      ) {
-        return current;
-      }
+      if (current.allAssetIds.length === ids.length && current.allAssetIds.every((id, index) => id === ids[index])) return current;
       return { ...current, allAssetIds: ids };
     });
   }, []);
+
+  const selectedIDs = Array.from(state.selectedAssets);
 
   const handleBulkRate = useCallback(async (rating: number) => {
     if (state.selectedAssets.size === 0) return;
@@ -261,12 +250,7 @@ export default function App() {
           <h1 className="text-lg font-semibold">ライブラリ情報を読み込めませんでした</h1>
           <p className="text-sm text-muted-foreground">Lumineのデータベースを開く際にエラーが発生しました。</p>
           <p className="text-xs text-muted-foreground/70 break-words font-mono">{bootstrapError}</p>
-          <button
-            onClick={() => void loadBootstrap()}
-            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium"
-          >
-            再試行
-          </button>
+          <button onClick={() => void loadBootstrap()} className="ui-primary-button">再試行</button>
         </div>
       </div>
     );
@@ -283,18 +267,16 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AppContext.Provider value={{ state, setState }}>
-        <div className="flex h-screen bg-background text-foreground">
+        <div className="app-shell flex h-screen bg-background text-foreground overflow-hidden">
           {state.sidebarOpen && <Sidebar />}
 
           <div className="flex flex-col flex-1 min-w-0">
             <Toolbar />
-            <div className="flex flex-1 min-h-0">
+            <div className="app-main-region relative flex flex-1 min-h-0 min-w-0">
               <div className="flex-1 min-w-0 flex">
-                <ViewerGrid onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} />
+                <ViewerGridV2 onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} />
               </div>
-              {state.detailOpen && state.detailAsset && (
-                <AssetDetailPanel assetId={state.detailAsset.id} onClose={handleCloseDetail} />
-              )}
+              {state.detailOpen && state.detailAsset && <AssetDetailPanel assetId={state.detailAsset.id} onClose={handleCloseDetail} />}
             </div>
 
             {state.selectedAssets.size > 1 && (
@@ -304,16 +286,21 @@ export default function App() {
                 onStatus={handleBulkStatus}
                 onFavorite={handleBulkFavorite}
                 onColorLabel={handleBulkColorLabel}
+                onPostRecord={() => setBulkPostRecordOpen(true)}
                 onDelete={handleBulkDelete}
-                onClear={() => setState((current) => ({
-                  ...current,
-                  selectedAssets: new Set(),
-                  lastSelectedIndex: null,
-                }))}
+                onClear={() => setState((current) => ({ ...current, selectedAssets: new Set(), lastSelectedIndex: null }))}
               />
             )}
           </div>
         </div>
+
+        {bulkPostRecordOpen && selectedIDs.length > 0 && (
+          <PostRecordModal
+            assetIds={selectedIDs}
+            defaultTitle={`${selectedIDs.length}件の画像`}
+            onClose={() => setBulkPostRecordOpen(false)}
+          />
+        )}
       </AppContext.Provider>
     </QueryClientProvider>
   );
@@ -325,6 +312,7 @@ export function BulkActionsBar({
   onStatus,
   onFavorite,
   onColorLabel,
+  onPostRecord,
   onDelete,
   onClear,
 }: {
@@ -333,6 +321,7 @@ export function BulkActionsBar({
   onStatus: (status: string) => void;
   onFavorite: (favorite: boolean) => void;
   onColorLabel: (label: string) => void;
+  onPostRecord: () => void;
   onDelete: () => void;
   onClear: () => void;
 }) {
@@ -344,63 +333,33 @@ export function BulkActionsBar({
   ];
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2.5 border-t border-border bg-card shadow-[0_-8px_24px_rgba(0,0,0,0.15)] flex-shrink-0 overflow-x-auto">
+    <div className="min-h-14 flex items-center gap-2 px-3 py-2 border-t border-border bg-card shadow-[0_-8px_24px_rgba(0,0,0,0.15)] flex-shrink-0 overflow-x-auto">
       <span className="text-xs font-semibold whitespace-nowrap">{count}件を選択中</span>
       <div className="h-5 w-px bg-border" />
 
       <div className="flex items-center gap-1 whitespace-nowrap">
-        <span className="text-xs text-muted-foreground mr-1">評価</span>
-        {[1, 2, 3, 4, 5].map((rating) => (
-          <button
-            key={rating}
-            onClick={() => onRate(rating)}
-            className="w-7 h-7 rounded-md hover:bg-accent text-yellow-400 transition-colors"
-            title={`評価を${rating}に設定`}
-          >
-            ★
-          </button>
-        ))}
+        <span className="text-[11px] text-muted-foreground mr-1">評価</span>
+        {[1, 2, 3, 4, 5].map((rating) => <button key={rating} onClick={() => onRate(rating)} className="w-8 h-8 rounded-lg hover:bg-accent text-yellow-400" title={`評価を${rating}に設定`}>★</button>)}
       </div>
 
       <div className="h-5 w-px bg-border" />
       <div className="flex items-center gap-1 whitespace-nowrap">
-        <span className="text-xs text-muted-foreground mr-1">状態</span>
-        {statuses.map((status) => (
-          <button
-            key={status.value}
-            onClick={() => onStatus(status.value)}
-            className="text-xs px-2 py-1 rounded-md bg-muted text-muted-foreground border border-border hover:bg-accent hover:text-foreground transition-colors"
-          >
-            {status.label}
-          </button>
-        ))}
+        <span className="text-[11px] text-muted-foreground mr-1">状態</span>
+        {statuses.map((status) => <button key={status.value} onClick={() => onStatus(status.value)} className="ui-secondary-button">{status.label}</button>)}
       </div>
 
       <div className="h-5 w-px bg-border" />
-      <div className="flex items-center gap-1 whitespace-nowrap">
-        <span className="text-xs text-muted-foreground mr-1">色</span>
+      <button onClick={() => onFavorite(true)} className="ui-secondary-button whitespace-nowrap">★ お気に入り</button>
+      <button onClick={onPostRecord} className="ui-primary-button whitespace-nowrap">＋ 投稿記録</button>
+      <button onClick={onDelete} className="h-8 px-3 rounded-lg bg-destructive text-destructive-foreground text-[11px] font-medium whitespace-nowrap">一覧から削除</button>
+      <div className="flex-1 min-w-3" />
+      <button onClick={onClear} className="ui-secondary-button whitespace-nowrap">選択解除</button>
+
+      <div className="hidden">
         {["", "red", "orange", "yellow", "green", "blue", "purple"].map((label) => (
-          <button
-            key={label || "none"}
-            onClick={() => onColorLabel(label)}
-            className="w-5 h-5 rounded-full border border-border hover:scale-110 transition-transform"
-            style={{ backgroundColor: label || "transparent" }}
-            title={label ? `${label}ラベル` : "カラーラベルを解除"}
-          />
+          <button key={label || "none"} onClick={() => onColorLabel(label)}>{label || "none"}</button>
         ))}
       </div>
-
-      <div className="h-5 w-px bg-border" />
-      <button onClick={() => onFavorite(true)} className="text-xs px-2.5 py-1.5 bg-muted rounded-md hover:bg-accent whitespace-nowrap">
-        ★ お気に入り
-      </button>
-      <button onClick={onDelete} className="text-xs px-2.5 py-1.5 bg-destructive text-destructive-foreground rounded-md hover:opacity-90 whitespace-nowrap">
-        一覧から削除
-      </button>
-      <div className="flex-1 min-w-4" />
-      <button onClick={onClear} className="text-xs px-2.5 py-1.5 text-muted-foreground hover:text-foreground whitespace-nowrap">
-        選択を解除
-      </button>
     </div>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,31 @@ export type PostDTO = cmds.PostDTO;
 export type PostTargetDTO = cmds.PostTargetDTO;
 export type PostAccountDTO = cmds.PostAccountDTO;
 
+export interface PostRecordRequest {
+  assetIds: number[];
+  targetId: number;
+  accountId: number;
+  title: string;
+  externalPostId: string;
+}
+
+export interface PostRecordDTO {
+  id: number;
+  title: string;
+  status: string;
+  publishedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  assetIds: number[];
+  targetId: number;
+  targetName: string;
+  targetKind: string;
+  accountId: number;
+  accountDisplay: string;
+  accountIdentifier: string;
+  externalPostId?: string;
+}
+
 export interface ScanProgress {
   libraryId: number;
   scannedCount: number;
@@ -40,13 +65,16 @@ export const getSupportedExtensions = Go.GetSupportedExtensions;
 export const setSupportedExtensions = Go.SetSupportedExtensions;
 export const listAssets = Go.ListAssets;
 
-function viewerCommands() {
+function appCommands() {
   return (window as unknown as {
     go?: {
       commands?: {
         AppCommands?: {
           GetViewerAssetDetail?: (id: number) => Promise<AssetDTO | null>;
           ScanLibraryViewer?: (libraryId: number) => Promise<void>;
+          CreatePostRecord?: (request: PostRecordRequest) => Promise<PostRecordDTO | null>;
+          ListPostRecords?: (offset: number, limit: number) => Promise<PostRecordDTO[]>;
+          GetPostRecordsByAsset?: (assetId: number) => Promise<PostRecordDTO[]>;
         };
       };
     };
@@ -54,13 +82,13 @@ function viewerCommands() {
 }
 
 export async function getAssetDetail(assetId: number): Promise<AssetDTO | null> {
-  const method = viewerCommands()?.GetViewerAssetDetail;
+  const method = appCommands()?.GetViewerAssetDetail;
   if (!method) return Go.GetAssetDetail(assetId);
   return method(assetId);
 }
 
 export async function scanLibrary(libraryId: number): Promise<void> {
-  const method = viewerCommands()?.ScanLibraryViewer;
+  const method = appCommands()?.ScanLibraryViewer;
   if (method) await method(libraryId);
   else await Go.ScanLibrary(libraryId);
 
@@ -68,6 +96,29 @@ export async function scanLibrary(libraryId: number): Promise<void> {
     queryClient.invalidateQueries({ queryKey: ["assets", libraryId] }),
     queryClient.invalidateQueries({ queryKey: ["folderTree", libraryId] }),
   ]);
+}
+
+export async function createPostRecord(request: PostRecordRequest): Promise<PostRecordDTO | null> {
+  const method = appCommands()?.CreatePostRecord;
+  if (!method) throw new Error("投稿記録APIが利用できません。最新版のLumineを起動してください。");
+  const record = await method(request);
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["postRecords"] }),
+    ...request.assetIds.map((assetId) => queryClient.invalidateQueries({ queryKey: ["assetPostRecords", assetId] })),
+  ]);
+  return record;
+}
+
+export async function listPostRecords(offset = 0, limit = 100): Promise<PostRecordDTO[]> {
+  const method = appCommands()?.ListPostRecords;
+  if (!method) return [];
+  return (await method(offset, limit)) ?? [];
+}
+
+export async function getPostRecordsByAsset(assetId: number): Promise<PostRecordDTO[]> {
+  const method = appCommands()?.GetPostRecordsByAsset;
+  if (!method) return [];
+  return (await method(assetId)) ?? [];
 }
 
 export const updateAssetNote = Go.UpdateAssetNote;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,12 @@ export interface PostRecordRequest {
   externalPostId: string;
 }
 
+export interface PostRecordAssetDTO {
+  id: number;
+  fileName: string;
+  filePath: string;
+}
+
 export interface PostRecordDTO {
   id: number;
   title: string;
@@ -33,6 +39,7 @@ export interface PostRecordDTO {
   createdAt: string;
   updatedAt: string;
   assetIds: number[];
+  assets: PostRecordAssetDTO[];
   targetId: number;
   targetName: string;
   targetKind: string;

--- a/frontend/src/components/AssetDetailPanel.tsx
+++ b/frontend/src/components/AssetDetailPanel.tsx
@@ -1,1 +1,306 @@
-export { ViewerDetailPanel as AssetDetailPanel } from "./ViewerDetailPanel";
+import { useCallback, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getAssetDetail,
+  getPostRecordsByAsset,
+  listTags,
+  setAssetTags,
+  toggleAssetFavorite,
+  updateAssetColorLabel,
+  updateAssetNote,
+  updateAssetRating,
+  updateAssetStatus,
+} from "../api/client";
+import { formatFileSize } from "../utils/format";
+import { ImageViewerModal } from "./ImageViewerModal";
+import { MemoryImage } from "./MemoryImage";
+import { PostRecordModal } from "./PostRecordModal";
+
+interface AssetDetailPanelProps {
+  assetId: number;
+  onClose: () => void;
+}
+
+const STATUS_OPTIONS = [
+  { value: "unsorted", label: "未整理" },
+  { value: "reviewed", label: "確認済み" },
+  { value: "candidate", label: "候補" },
+  { value: "published", label: "公開済み" },
+];
+
+const COLORS = ["", "red", "orange", "yellow", "green", "blue", "purple"];
+
+export function AssetDetailPanel({ assetId, onClose }: AssetDetailPanelProps) {
+  const queryClient = useQueryClient();
+  const [showViewer, setShowViewer] = useState(false);
+  const [showPostRecord, setShowPostRecord] = useState(false);
+  const [note, setNote] = useState("");
+  const [noteDirty, setNoteDirty] = useState(false);
+
+  const { data: asset, isLoading, isError, error } = useQuery({
+    queryKey: ["assetDetail", assetId],
+    queryFn: () => getAssetDetail(assetId),
+    enabled: assetId > 0,
+    staleTime: Infinity,
+  });
+  const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
+  const { data: postRecords = [] } = useQuery({
+    queryKey: ["assetPostRecords", assetId],
+    queryFn: () => getPostRecordsByAsset(assetId),
+    enabled: assetId > 0,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    if (!asset) return;
+    setNote(asset.noteContent ?? "");
+    setNoteDirty(false);
+  }, [asset?.id, asset?.noteContent]);
+
+  useEffect(() => {
+    setShowViewer(false);
+    setShowPostRecord(false);
+  }, [assetId]);
+
+  const refreshDetail = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ["assetDetail", assetId] });
+  }, [assetId, queryClient]);
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["assetDetail", assetId] }),
+      queryClient.invalidateQueries({ queryKey: ["assets"] }),
+    ]);
+  }, [assetId, queryClient]);
+
+  const saveNote = useCallback(async () => {
+    if (!asset || !noteDirty) return;
+    await updateAssetNote(asset.id, note);
+    setNoteDirty(false);
+    await refreshDetail();
+  }, [asset, note, noteDirty, refreshDetail]);
+
+  if (isLoading) {
+    return (
+      <aside className="app-detail-panel border-l border-border bg-card flex items-center justify-center">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="w-4 h-4 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" />
+          詳細を読み込み中…
+        </div>
+      </aside>
+    );
+  }
+
+  if (isError || !asset) {
+    return (
+      <aside className="app-detail-panel border-l border-border bg-card flex flex-col items-center justify-center gap-3 p-5">
+        <p className="text-xs font-medium text-destructive">画像の詳細を開けませんでした</p>
+        {error && <p className="text-[11px] text-muted-foreground text-center break-all">{String(error)}</p>}
+        <button className="ui-secondary-button" onClick={onClose}>閉じる</button>
+      </aside>
+    );
+  }
+
+  return (
+    <>
+      <aside className="app-detail-panel border-l border-border bg-card flex flex-col overflow-hidden shadow-[-8px_0_24px_rgba(0,0,0,0.08)]">
+        <div className="min-h-14 px-3.5 py-2 border-b border-border flex items-center justify-between gap-3 flex-shrink-0">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold">画像の詳細</p>
+            <p className="text-[11px] text-muted-foreground truncate">確認・整理・投稿記録</p>
+          </div>
+          <button className="ui-icon-button text-lg" onClick={onClose} aria-label="詳細パネルを閉じる">×</button>
+        </div>
+
+        <div className="flex-1 overflow-auto p-3 space-y-4">
+          <section className="space-y-2">
+            <button
+              onClick={() => setShowViewer(true)}
+              className="relative block w-full rounded-xl border border-border bg-muted/25 overflow-hidden group focus:outline-none focus:ring-2 focus:ring-primary"
+              title="大きく表示"
+            >
+              <div className="flex justify-center">
+                <MemoryImage
+                  filePath={asset.filePath}
+                  modifiedAtFs={asset.modifiedAtFs}
+                  sourceWidth={asset.width}
+                  sourceHeight={asset.height}
+                  width={300}
+                  height={240}
+                  fit="contain"
+                  alt={asset.fileName}
+                />
+              </div>
+              <div className="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-black/75 to-transparent" />
+              <span className="absolute bottom-2 right-2 h-8 px-3 inline-flex items-center rounded-lg bg-black/70 border border-white/15 text-[11px] font-medium text-white">
+                ⛶ 大きく表示
+              </span>
+            </button>
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold leading-snug break-words">{asset.fileName}</h3>
+              <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground break-all">{asset.filePath}</p>
+            </div>
+          </section>
+
+          <section className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-muted/20 p-3">
+            <Info label="ファイルサイズ" value={formatFileSize(asset.fileSize)} />
+            <Info label="形式" value={asset.extension.toUpperCase()} />
+            {asset.width > 0 && asset.height > 0 && <Info label="解像度" value={`${asset.width} × ${asset.height}`} />}
+            <Info label="更新日" value={asset.modifiedAtFs ? new Date(asset.modifiedAtFs).toLocaleDateString("ja-JP") : "-"} />
+          </section>
+
+          <Section title="整理">
+            <div className="space-y-3">
+              <div>
+                <p className="ui-label mb-1.5">評価</p>
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4, 5].map((rating) => (
+                    <button
+                      key={rating}
+                      className={`w-8 h-8 rounded-lg text-lg hover:bg-accent ${rating <= asset.rating ? "text-yellow-400" : "text-muted-foreground/25"}`}
+                      onClick={async () => { await updateAssetRating(asset.id, rating); await refreshAll(); }}
+                      aria-label={`評価 ${rating}`}
+                    >★</button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <p className="ui-label mb-1.5">状態</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {STATUS_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      onClick={async () => { await updateAssetStatus(asset.id, option.value); await refreshAll(); }}
+                      className={`h-8 px-2.5 rounded-lg border text-[11px] ${asset.statusLabel === option.value ? "bg-primary border-primary text-primary-foreground" : "bg-muted border-border text-muted-foreground hover:text-foreground"}`}
+                    >{option.label}</button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-3">
+                <span className="ui-label">お気に入り</span>
+                <button
+                  className={`ui-secondary-button ${asset.isFavorite ? "text-yellow-400 border-yellow-400/30" : ""}`}
+                  onClick={async () => { await toggleAssetFavorite(asset.id, !asset.isFavorite); await refreshAll(); }}
+                >★ {asset.isFavorite ? "登録済み" : "登録する"}</button>
+              </div>
+
+              <div>
+                <p className="ui-label mb-1.5">カラーラベル</p>
+                <div className="flex gap-2">
+                  {COLORS.map((color) => (
+                    <button
+                      key={color || "none"}
+                      className={`w-6 h-6 rounded-full border border-border ${asset.colorLabel === color ? "ring-2 ring-primary ring-offset-2 ring-offset-card" : ""}`}
+                      style={{ backgroundColor: color || "transparent" }}
+                      onClick={async () => { await updateAssetColorLabel(asset.id, color); await refreshAll(); }}
+                      aria-label={color || "カラーラベルなし"}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section title="タグ">
+            <div className="flex flex-wrap gap-1.5">
+              {tags.length > 0 ? tags.map((tag) => {
+                const active = asset.tags?.some((item) => item.id === tag.id) ?? false;
+                return (
+                  <button
+                    key={tag.id}
+                    onClick={async () => {
+                      const current = asset.tags?.map((item) => item.id) ?? [];
+                      const next = active ? current.filter((id) => id !== tag.id) : [...current, tag.id];
+                      await setAssetTags(asset.id, next);
+                      await refreshAll();
+                    }}
+                    className={`h-7 px-2.5 rounded-full border text-[11px] ${active ? "bg-primary/15 border-primary/40 text-foreground" : "bg-muted border-border text-muted-foreground"}`}
+                  >
+                    <span className="inline-block w-2 h-2 rounded-full mr-1" style={{ backgroundColor: tag.color }} />{tag.name}
+                  </button>
+                );
+              }) : <p className="text-[11px] text-muted-foreground">タグはまだありません。</p>}
+            </div>
+          </Section>
+
+          <Section title="メモ">
+            <textarea
+              value={note}
+              onChange={(event) => { setNote(event.target.value); setNoteDirty(true); }}
+              onBlur={() => void saveNote()}
+              placeholder="この画像についてメモを残す…"
+              className="ui-input w-full min-h-24 resize-y leading-relaxed"
+            />
+            <div className="mt-1.5 min-h-5 flex justify-end">
+              {noteDirty ? <button className="ui-primary-button" onClick={() => void saveNote()}>保存</button> : <span className="text-[11px] text-muted-foreground">変更は自動保存されます</span>}
+            </div>
+          </Section>
+
+          <Section title="投稿記録">
+            <button className="ui-primary-button w-full justify-center" onClick={() => setShowPostRecord(true)}>
+              ＋ この画像の投稿記録を追加
+            </button>
+            <div className="mt-2 space-y-2">
+              {postRecords.map((record) => (
+                <div key={record.id} className="rounded-lg border border-border bg-muted/25 p-2.5">
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-medium truncate">{record.targetName}</p>
+                      <p className="text-[11px] text-muted-foreground truncate">{record.accountDisplay}{record.accountIdentifier ? ` · ${record.accountIdentifier}` : ""}</p>
+                    </div>
+                    <span className="text-[10px] text-muted-foreground whitespace-nowrap">{record.publishedAt ? new Date(record.publishedAt).toLocaleDateString("ja-JP") : ""}</span>
+                  </div>
+                  {record.externalPostId && <p className="mt-1.5 text-[11px] text-primary break-all">{record.externalPostId}</p>}
+                </div>
+              ))}
+              {postRecords.length === 0 && <p className="text-[11px] text-muted-foreground text-center py-2">まだ投稿記録はありません</p>}
+            </div>
+          </Section>
+
+          {(asset.cameraModel || asset.lensModel || asset.focalLength || asset.aperture || asset.shutterSpeed || asset.iso || asset.exifDate) && (
+            <Section title="撮影情報 (EXIF)">
+              <div className="space-y-1.5">
+                {asset.cameraModel && <Meta label="カメラ" value={asset.cameraModel} />}
+                {asset.lensModel && <Meta label="レンズ" value={asset.lensModel} />}
+                {asset.focalLength && <Meta label="焦点距離" value={asset.focalLength} />}
+                {asset.aperture && <Meta label="絞り" value={asset.aperture} />}
+                {asset.shutterSpeed && <Meta label="シャッター" value={asset.shutterSpeed} />}
+                {asset.iso ? <Meta label="ISO" value={String(asset.iso)} /> : null}
+                {asset.exifDate && <Meta label="撮影日時" value={asset.exifDate} />}
+              </div>
+            </Section>
+          )}
+        </div>
+      </aside>
+
+      {showViewer && <ImageViewerModal asset={asset} onClose={() => setShowViewer(false)} />}
+      {showPostRecord && (
+        <PostRecordModal
+          assetIds={[asset.id]}
+          defaultTitle={asset.fileName}
+          onClose={() => setShowPostRecord(false)}
+          onSaved={() => void queryClient.invalidateQueries({ queryKey: ["assetPostRecords", asset.id] })}
+        />
+      )}
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="border-t border-border pt-3">
+      <h4 className="mb-2 text-[11px] font-semibold text-muted-foreground">{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function Info({ label, value }: { label: string; value: string }) {
+  return <div><p className="text-[10px] text-muted-foreground">{label}</p><p className="mt-0.5 text-xs break-words">{value}</p></div>;
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return <div className="flex justify-between gap-3 text-[11px]"><span className="text-muted-foreground flex-shrink-0">{label}</span><span className="text-right break-all">{value}</span></div>;
+}

--- a/frontend/src/components/AssetDetailPanel.tsx
+++ b/frontend/src/components/AssetDetailPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AssetDTO } from "../api/client";
 import {
   getAssetDetail,
   getPostRecordsByAsset,
@@ -17,7 +18,7 @@ import { MemoryImage } from "./MemoryImage";
 import { PostRecordModal } from "./PostRecordModal";
 
 interface AssetDetailPanelProps {
-  assetId: number;
+  asset: AssetDTO;
   onClose: () => void;
 }
 
@@ -30,37 +31,55 @@ const STATUS_OPTIONS = [
 
 const COLORS = ["", "red", "orange", "yellow", "green", "blue", "purple"];
 
-export function AssetDetailPanel({ assetId, onClose }: AssetDetailPanelProps) {
+export function AssetDetailPanel({ asset: listAsset, onClose }: AssetDetailPanelProps) {
   const queryClient = useQueryClient();
+  const assetId = listAsset.id;
   const [showViewer, setShowViewer] = useState(false);
   const [showPostRecord, setShowPostRecord] = useState(false);
-  const [note, setNote] = useState("");
+  const [note, setNote] = useState(listAsset.noteContent ?? "");
   const [noteDirty, setNoteDirty] = useState(false);
 
-  const { data: asset, isLoading, isError, error } = useQuery({
+  const {
+    data: detailedAsset,
+    isFetching: detailFetching,
+    isError: detailError,
+    error,
+  } = useQuery({
     queryKey: ["assetDetail", assetId],
-    queryFn: () => getAssetDetail(assetId),
+    queryFn: async () => {
+      const detail = await getAssetDetail(assetId);
+      if (!detail) throw new Error("画像の詳細情報を取得できませんでした");
+      return detail;
+    },
     enabled: assetId > 0,
-    staleTime: Infinity,
+    staleTime: 30_000,
+    retry: 2,
   });
+
+  // The lightweight list DTO is always enough to render the panel immediately.
+  // EXIF/tags/note arrive asynchronously and enrich the same panel afterwards.
+  // This avoids a blank detail pane for newly scanned or freshly paged assets.
+  const asset = detailedAsset ?? listAsset;
+
   const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
   const { data: postRecords = [] } = useQuery({
     queryKey: ["assetPostRecords", assetId],
     queryFn: () => getPostRecordsByAsset(assetId),
     enabled: assetId > 0,
-    staleTime: Infinity,
+    staleTime: 30_000,
   });
-
-  useEffect(() => {
-    if (!asset) return;
-    setNote(asset.noteContent ?? "");
-    setNoteDirty(false);
-  }, [asset?.id, asset?.noteContent]);
 
   useEffect(() => {
     setShowViewer(false);
     setShowPostRecord(false);
-  }, [assetId]);
+    setNote(listAsset.noteContent ?? "");
+    setNoteDirty(false);
+  }, [assetId, listAsset.noteContent]);
+
+  useEffect(() => {
+    if (!detailedAsset || noteDirty) return;
+    setNote(detailedAsset.noteContent ?? "");
+  }, [detailedAsset, noteDirty]);
 
   const refreshDetail = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ["assetDetail", assetId] });
@@ -74,45 +93,35 @@ export function AssetDetailPanel({ assetId, onClose }: AssetDetailPanelProps) {
   }, [assetId, queryClient]);
 
   const saveNote = useCallback(async () => {
-    if (!asset || !noteDirty) return;
-    await updateAssetNote(asset.id, note);
+    if (!noteDirty) return;
+    await updateAssetNote(assetId, note);
     setNoteDirty(false);
     await refreshDetail();
-  }, [asset, note, noteDirty, refreshDetail]);
-
-  if (isLoading) {
-    return (
-      <aside className="app-detail-panel border-l border-border bg-card flex items-center justify-center">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <div className="w-4 h-4 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" />
-          詳細を読み込み中…
-        </div>
-      </aside>
-    );
-  }
-
-  if (isError || !asset) {
-    return (
-      <aside className="app-detail-panel border-l border-border bg-card flex flex-col items-center justify-center gap-3 p-5">
-        <p className="text-xs font-medium text-destructive">画像の詳細を開けませんでした</p>
-        {error && <p className="text-[11px] text-muted-foreground text-center break-all">{String(error)}</p>}
-        <button className="ui-secondary-button" onClick={onClose}>閉じる</button>
-      </aside>
-    );
-  }
+  }, [assetId, note, noteDirty, refreshDetail]);
 
   return (
     <>
       <aside className="app-detail-panel border-l border-border bg-card flex flex-col overflow-hidden shadow-[-8px_0_24px_rgba(0,0,0,0.08)]">
         <div className="min-h-14 px-3.5 py-2 border-b border-border flex items-center justify-between gap-3 flex-shrink-0">
           <div className="min-w-0">
-            <p className="text-xs font-semibold">画像の詳細</p>
+            <div className="flex items-center gap-2">
+              <p className="text-xs font-semibold">画像の詳細</p>
+              {detailFetching && <span className="w-3 h-3 border-2 border-muted-foreground/25 border-t-primary rounded-full animate-spin" title="詳細情報を読み込み中" />}
+            </div>
             <p className="text-[11px] text-muted-foreground truncate">確認・整理・投稿記録</p>
           </div>
           <button className="ui-icon-button text-lg" onClick={onClose} aria-label="詳細パネルを閉じる">×</button>
         </div>
 
         <div className="flex-1 overflow-auto p-3 space-y-4">
+          {detailError && (
+            <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-200">
+              基本情報を表示しています。追加情報の読み込みに失敗しました。
+              {error ? <span className="block mt-1 text-amber-200/70 break-all">{String(error)}</span> : null}
+              <button className="mt-2 underline underline-offset-2" onClick={() => void refreshDetail()}>再読み込み</button>
+            </div>
+          )}
+
           <section className="space-y-2">
             <button
               onClick={() => setShowViewer(true)}

--- a/frontend/src/components/ImageViewerModal.tsx
+++ b/frontend/src/components/ImageViewerModal.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { AssetDTO } from "../api/client";
+import { getLocalImageUrl } from "../api/client";
+import { MemoryImage } from "./MemoryImage";
+
+interface ImageViewerModalProps {
+  asset: AssetDTO;
+  onClose: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+  hasPrev?: boolean;
+  hasNext?: boolean;
+}
+
+export function ImageViewerModal({
+  asset,
+  onClose,
+  onPrev,
+  onNext,
+  hasPrev = false,
+  hasNext = false,
+}: ImageViewerModalProps) {
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const [originalLoaded, setOriginalLoaded] = useState(false);
+  const dragOrigin = useRef({ x: 0, y: 0 });
+  const [viewport, setViewport] = useState(() => ({
+    width: Math.max(320, window.innerWidth - 48),
+    height: Math.max(240, window.innerHeight - 132),
+  }));
+
+  const reset = useCallback(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+    setDragging(false);
+    setOriginalLoaded(false);
+  }, []);
+
+  useEffect(() => reset(), [asset.id, reset]);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const update = () => setViewport({
+      width: Math.max(320, window.innerWidth - 48),
+      height: Math.max(240, window.innerHeight - 132),
+    });
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+      if (event.key === "ArrowLeft" && hasPrev && onPrev) {
+        event.preventDefault();
+        onPrev();
+      }
+      if (event.key === "ArrowRight" && hasNext && onNext) {
+        event.preventDefault();
+        onNext();
+      }
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        setZoom((value) => Math.min(8, value + 0.5));
+      }
+      if (event.key === "-") {
+        event.preventDefault();
+        setZoom((value) => Math.max(1, value - 0.5));
+      }
+      if (event.key === "0") {
+        event.preventDefault();
+        reset();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [hasNext, hasPrev, onClose, onNext, onPrev, reset]);
+
+  useEffect(() => {
+    if (zoom <= 1) {
+      setOriginalLoaded(false);
+      setPan({ x: 0, y: 0 });
+    }
+  }, [zoom]);
+
+  const handleWheel = useCallback((event: React.WheelEvent) => {
+    event.preventDefault();
+    setZoom((value) => Math.max(1, Math.min(8, value - event.deltaY * 0.0016)));
+  }, []);
+
+  const beginDrag = useCallback((event: React.MouseEvent) => {
+    if (zoom <= 1) return;
+    setDragging(true);
+    dragOrigin.current = { x: event.clientX, y: event.clientY };
+  }, [zoom]);
+
+  const moveDrag = useCallback((event: React.MouseEvent) => {
+    if (!dragging || zoom <= 1) return;
+    setPan((current) => ({
+      x: current.x + event.clientX - dragOrigin.current.x,
+      y: current.y + event.clientY - dragOrigin.current.y,
+    }));
+    dragOrigin.current = { x: event.clientX, y: event.clientY };
+  }, [dragging, zoom]);
+
+  const needsOriginal = zoom > 1;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] bg-black/96 text-white"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${asset.fileName} を大きく表示`}
+      onClick={onClose}
+    >
+      <div className="absolute inset-x-0 top-0 h-16 px-4 flex items-center gap-3 bg-gradient-to-b from-black/80 to-transparent z-20 pointer-events-none">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold truncate">{asset.fileName}</p>
+          <p className="text-[11px] text-white/55 truncate">ホイール: 拡大縮小 / ドラッグ: 移動 / 0: 全体表示 / Esc: 閉じる</p>
+        </div>
+        <div className="flex items-center gap-1.5 pointer-events-auto" onClick={(event) => event.stopPropagation()}>
+          <button className="viewer-control" onClick={() => setZoom((value) => Math.max(1, value - 0.5))} aria-label="縮小">−</button>
+          <span className="min-w-14 text-center text-xs text-white/75 tabular-nums">{Math.round(zoom * 100)}%</span>
+          <button className="viewer-control" onClick={() => setZoom((value) => Math.min(8, value + 0.5))} aria-label="拡大">＋</button>
+          <button className="viewer-control px-3 text-xs" onClick={reset}>全体</button>
+          <button className="viewer-control text-lg" onClick={onClose} aria-label="閉じる">×</button>
+        </div>
+      </div>
+
+      <div
+        className="absolute inset-0 flex items-center justify-center overflow-hidden select-none"
+        onClick={(event) => event.stopPropagation()}
+        onWheel={handleWheel}
+        onMouseDown={beginDrag}
+        onMouseMove={moveDrag}
+        onMouseUp={() => setDragging(false)}
+        onMouseLeave={() => setDragging(false)}
+        onDoubleClick={() => (zoom > 1 ? reset() : setZoom(2.5))}
+      >
+        {(!needsOriginal || !originalLoaded) && (
+          <MemoryImage
+            filePath={asset.filePath}
+            modifiedAtFs={asset.modifiedAtFs}
+            sourceWidth={asset.width}
+            sourceHeight={asset.height}
+            width={viewport.width}
+            height={viewport.height}
+            fit="contain"
+            alt={asset.fileName}
+            className="bg-black"
+          />
+        )}
+        {needsOriginal && (
+          <img
+            src={getLocalImageUrl(asset.filePath)}
+            alt={asset.fileName}
+            decoding="async"
+            draggable={false}
+            onLoad={() => setOriginalLoaded(true)}
+            onError={() => setOriginalLoaded(false)}
+            className={`${originalLoaded ? "block" : "absolute opacity-0 pointer-events-none"} max-w-[calc(100vw-48px)] max-h-[calc(100vh-132px)] object-contain`}
+            style={{
+              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+              transformOrigin: "center center",
+              cursor: zoom > 1 ? (dragging ? "grabbing" : "grab") : "zoom-in",
+              transition: dragging ? "none" : "transform 80ms ease-out",
+            }}
+          />
+        )}
+      </div>
+
+      {onPrev && (
+        <button
+          onClick={(event) => { event.stopPropagation(); onPrev(); }}
+          disabled={!hasPrev}
+          className="viewer-nav left-4"
+          aria-label="前の画像"
+        >
+          ‹
+        </button>
+      )}
+      {onNext && (
+        <button
+          onClick={(event) => { event.stopPropagation(); onNext(); }}
+          disabled={!hasNext}
+          className="viewer-nav right-4"
+          aria-label="次の画像"
+        >
+          ›
+        </button>
+      )}
+
+      <div className="absolute inset-x-0 bottom-3 flex justify-center pointer-events-none">
+        <div className="rounded-full bg-black/55 border border-white/10 px-3 py-1.5 text-[11px] text-white/60 backdrop-blur-sm">
+          ダブルクリックで拡大 / もう一度ダブルクリックで全体表示
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/NavigationV2.tsx
+++ b/frontend/src/components/NavigationV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApp } from "../App";
 import {
@@ -267,7 +267,7 @@ function PostRecordsPanel() {
                   <p className="text-xs font-medium truncate">{record.targetName} · {record.accountDisplay}</p>
                   <p className="mt-0.5 text-[10px] text-muted-foreground truncate">{record.title || "投稿記録"} · 画像{record.assetIds.length}件</p>
                 </div>
-                <button className="text-[10px] text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm("この投稿記録を削除しますか？")) return; await deletePost(record.id); await queryClient.invalidateQueries({ queryKey: ["postRecords"] }); }}>削除</button>
+                <button className="text-[10px] text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm("この投稿記録を削除しますか？")) return; await deletePost(record.id); await Promise.all([queryClient.invalidateQueries({ queryKey: ["postRecords"] }), queryClient.invalidateQueries({ queryKey: ["assetPostRecords"] })]); }}>削除</button>
               </div>
               <p className="mt-1.5 text-[10px] text-muted-foreground">{record.publishedAt ? new Date(record.publishedAt).toLocaleString("ja-JP") : ""}</p>
               {record.externalPostId && <p className="mt-1 text-[10px] text-primary break-all">{record.externalPostId}</p>}
@@ -286,14 +286,14 @@ function PostRecordsPanel() {
                 <select className="ui-input" value={targetKind} onChange={(event) => setTargetKind(event.target.value)}><option value="pixiv">Pixiv</option><option value="twitter">X</option><option value="misskey">Misskey</option><option value="bluesky">Bluesky</option><option value="other">その他</option></select>
                 <button className="ui-primary-button" onClick={async () => { if (!targetName.trim()) return; await createPostTarget(targetName.trim(), targetKind); setTargetName(""); await reloadSettings(); }}>追加</button>
               </div>
-              {targets.map((target) => <div key={target.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{target.name} ({target.kind})</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { await deletePostTarget(target.id); await reloadSettings(); }}>削除</button></div>)}
+              {targets.map((target) => <div key={target.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{target.name} ({target.kind})</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm(`投稿先「${target.name}」を削除すると、その投稿先を使った既存の投稿記録との紐付けも失われます。\n\n本当に削除しますか？`)) return; await deletePostTarget(target.id); await reloadSettings(); await queryClient.invalidateQueries({ queryKey: ["postRecords"] }); }}>削除</button></div>)}
             </div>
             <div className="space-y-2 border-t border-border pt-3">
               <p className="ui-label">アカウント</p>
               <select className="ui-input w-full" value={accountTargetId} onChange={(event) => setAccountTargetId(Number(event.target.value))}>{targets.map((target) => <option key={target.id} value={target.id}>{target.name}</option>)}</select>
               <input className="ui-input w-full" value={accountName} onChange={(event) => setAccountName(event.target.value)} placeholder="表示名" />
               <div className="flex gap-1.5"><input className="ui-input min-w-0 flex-1" value={accountIdentifier} onChange={(event) => setAccountIdentifier(event.target.value)} placeholder="@username / ID" /><button className="ui-primary-button" onClick={async () => { if (!accountTargetId || !accountName.trim()) return; await createPostAccount(accountTargetId, accountName.trim(), accountIdentifier.trim()); setAccountName(""); setAccountIdentifier(""); await reloadSettings(); }}>追加</button></div>
-              {accounts.map((account) => <div key={account.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{account.displayName}{account.accountIdentifier ? ` · ${account.accountIdentifier}` : ""}</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { await deletePostAccount(account.id); await reloadSettings(); }}>削除</button></div>)}
+              {accounts.map((account) => <div key={account.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{account.displayName}{account.accountIdentifier ? ` · ${account.accountIdentifier}` : ""}</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm(`アカウント「${account.displayName}」を削除すると、そのアカウントを使った既存の投稿記録との紐付けも失われます。\n\n本当に削除しますか？`)) return; await deletePostAccount(account.id); await reloadSettings(); await queryClient.invalidateQueries({ queryKey: ["postRecords"] }); }}>削除</button></div>)}
             </div>
           </div>
         )}
@@ -335,7 +335,7 @@ export function ToolbarV2() {
   const library = state.libraries.find((item) => item.id === state.selectedLibraryId);
   const folderName = state.selectedFolderPath.split(/[\\/]/).pop() || "";
   useEffect(() => setSearch(state.searchQuery), [state.searchQuery]);
-  useEffect(() => () => timer.current && clearTimeout(timer.current), []);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
   const updateSearch = (value: string) => {
     setSearch(value);

--- a/frontend/src/components/NavigationV2.tsx
+++ b/frontend/src/components/NavigationV2.tsx
@@ -269,6 +269,17 @@ function PostRecordsPanel() {
                 </div>
                 <button className="text-[10px] text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm("この投稿記録を削除しますか？")) return; await deletePost(record.id); await Promise.all([queryClient.invalidateQueries({ queryKey: ["postRecords"] }), queryClient.invalidateQueries({ queryKey: ["assetPostRecords"] })]); }}>削除</button>
               </div>
+              {record.assets.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {record.assets.slice(0, 3).map((asset) => (
+                    <div key={asset.id} className="h-6 px-2 rounded-md bg-background/60 flex items-center gap-1.5" title={asset.filePath}>
+                      <span className="text-[10px] text-muted-foreground">画像</span>
+                      <span className="min-w-0 flex-1 truncate text-[10px]">{asset.fileName}</span>
+                    </div>
+                  ))}
+                  {record.assets.length > 3 && <p className="pl-2 text-[10px] text-muted-foreground">ほか {record.assets.length - 3}件</p>}
+                </div>
+              )}
               <p className="mt-1.5 text-[10px] text-muted-foreground">{record.publishedAt ? new Date(record.publishedAt).toLocaleString("ja-JP") : ""}</p>
               {record.externalPostId && <p className="mt-1 text-[10px] text-primary break-all">{record.externalPostId}</p>}
             </div>

--- a/frontend/src/components/NavigationV2.tsx
+++ b/frontend/src/components/NavigationV2.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useApp } from "../App";
+import {
+  addLibrary,
+  createPostAccount,
+  createPostTarget,
+  createTag,
+  deletePost,
+  deletePostAccount,
+  deletePostTarget,
+  deleteTag,
+  disableLibrary,
+  enableLibrary,
+  getFolderTree,
+  getSetting,
+  getSupportedExtensions,
+  listLibraries,
+  listPostAccounts,
+  listPostRecords,
+  listPostTargets,
+  listTags,
+  offScanProgress,
+  onScanProgress,
+  removeLibrary,
+  scanLibrary,
+  selectFolder,
+  setSetting,
+  setSupportedExtensions,
+} from "../api/client";
+import type { FolderDTO, PostAccountDTO, PostTargetDTO, ScanProgress } from "../api/client";
+
+const NAV_ITEMS = [
+  ["libraries", "ライブラリ", "画像フォルダー"],
+  ["folders", "フォルダー", "階層で絞り込み"],
+  ["tags", "タグ", "画像の分類"],
+  ["posts", "投稿記録", "投稿先を確認"],
+  ["settings", "設定", "読み込み・操作"],
+] as const;
+
+export function WelcomeScreenV2({ onSelectFolder, busy = false }: { onSelectFolder: () => void; busy?: boolean }) {
+  return (
+    <div className="h-screen bg-background flex items-center justify-center p-6">
+      <div className="w-full max-w-xl rounded-3xl border border-border bg-card p-8 sm:p-10 text-center shadow-2xl">
+        <div className="w-16 h-16 mx-auto rounded-2xl bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold">L</div>
+        <h1 className="mt-5 text-2xl font-bold">Lumine</h1>
+        <p className="mt-2 text-sm text-muted-foreground">画像を軽快に探し、確認し、投稿先まで記録する画像ライブラリ</p>
+        <div className="mt-7 rounded-2xl border border-border bg-muted/30 p-4 text-left">
+          <p className="text-sm font-medium">最初に画像フォルダーを登録してください</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">画像そのものをコピーせず、表示用サムネイルもディスクへ保存しません。</p>
+        </div>
+        <button onClick={onSelectFolder} disabled={busy} className="ui-primary-button mt-6 w-full justify-center h-11 text-sm">
+          {busy ? "画像を読み込んでいます…" : "画像フォルダーを追加"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SidebarV2() {
+  const { state, setState } = useApp();
+  const queryClient = useQueryClient();
+  const [scanProgress, setScanProgress] = useState<Record<number, ScanProgress>>({});
+  const timers = useRef<number[]>([]);
+
+  useEffect(() => {
+    onScanProgress((progress) => {
+      setScanProgress((current) => ({ ...current, [progress.libraryId]: progress }));
+      if (!progress.isDone) return;
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["assets", progress.libraryId] }),
+        queryClient.invalidateQueries({ queryKey: ["folderTree", progress.libraryId] }),
+        listLibraries().then((libraries) => setState((current) => ({ ...current, libraries }))),
+      ]);
+      const timer = window.setTimeout(() => setScanProgress((current) => {
+        const next = { ...current };
+        delete next[progress.libraryId];
+        return next;
+      }), 1500);
+      timers.current.push(timer);
+    });
+    return () => {
+      offScanProgress();
+      timers.current.forEach(window.clearTimeout);
+    };
+  }, [queryClient, setState]);
+
+  return (
+    <aside className="app-sidebar border-r border-border bg-card flex flex-col flex-shrink-0 overflow-hidden">
+      <div className="h-14 px-3.5 border-b border-border flex items-center gap-2.5 flex-shrink-0">
+        <div className="w-8 h-8 rounded-lg bg-primary text-primary-foreground flex items-center justify-center font-bold">L</div>
+        <div className="min-w-0">
+          <p className="text-sm font-bold">Lumine</p>
+          <p className="text-[11px] text-muted-foreground">画像ライブラリ</p>
+        </div>
+      </div>
+
+      <nav className="p-2 border-b border-border grid grid-cols-1 gap-1 flex-shrink-0">
+        {NAV_ITEMS.map(([key, label, description]) => (
+          <button
+            key={key}
+            onClick={() => setState((current) => ({ ...current, sidebarView: key }))}
+            className={`min-h-10 px-2.5 rounded-lg flex items-center gap-2 text-left ${state.sidebarView === key ? "bg-primary/10 text-foreground" : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"}`}
+          >
+            <span className="w-2 h-2 rounded-full border border-current flex-shrink-0" />
+            <span className="min-w-0">
+              <span className="block text-xs font-medium">{label}</span>
+              <span className="block text-[10px] truncate opacity-70">{description}</span>
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {state.sidebarView === "libraries" && <LibrariesPanel scanProgress={scanProgress} />}
+        {state.sidebarView === "folders" && <FoldersPanel />}
+        {state.sidebarView === "tags" && <TagsPanel />}
+        {state.sidebarView === "posts" && <PostRecordsPanel />}
+        {state.sidebarView === "settings" && <SettingsPanel />}
+      </div>
+    </aside>
+  );
+}
+
+function PanelTitle({ title, description, action }: { title: string; description: string; action?: React.ReactNode }) {
+  return (
+    <div className="px-3 pt-3 pb-2 flex items-start justify-between gap-2">
+      <div className="min-w-0"><p className="text-xs font-semibold">{title}</p><p className="text-[11px] text-muted-foreground leading-relaxed">{description}</p></div>
+      {action}
+    </div>
+  );
+}
+
+function LibrariesPanel({ scanProgress }: { scanProgress: Record<number, ScanProgress> }) {
+  const { state, setState } = useApp();
+  const add = async () => {
+    const path = await selectFolder();
+    if (!path) return;
+    const name = path.split(/[/\\]/).pop() || "画像フォルダー";
+    const library = await addLibrary(name, path);
+    if (!library) return;
+    const libraries = await listLibraries();
+    setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "" }));
+    await scanLibrary(library.id);
+  };
+
+  return (
+    <div className="pb-3">
+      <PanelTitle title="ライブラリ" description="画像フォルダーを登録して一覧化します。" action={<button className="ui-secondary-button" onClick={() => void add()}>＋ 追加</button>} />
+      <div className="px-2 space-y-1.5">
+        {state.libraries.map((library) => {
+          const selected = state.selectedLibraryId === library.id;
+          const progress = scanProgress[library.id];
+          return (
+            <div key={library.id} className={`rounded-xl border p-2.5 ${selected ? "border-primary/40 bg-primary/10" : "border-border bg-muted/15"}`}>
+              <button className="w-full text-left min-w-0" onClick={() => setState((current) => ({ ...current, selectedLibraryId: library.id, selectedFolderPath: "", selectedAssets: new Set(), detailOpen: false, detailAsset: null }))}>
+                <p className="text-xs font-medium truncate">{library.name}</p>
+                <p className="mt-0.5 text-[10px] text-muted-foreground truncate">{library.rootPath}</p>
+              </button>
+              {progress && !progress.isDone && <p className="mt-2 text-[10px] text-muted-foreground">スキャン中… {progress.scannedCount.toLocaleString()}件</p>}
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <button className="ui-mini-button" onClick={() => void scanLibrary(library.id)} disabled={!library.isEnabled || !!progress}>再スキャン</button>
+                <button className="ui-mini-button" onClick={async () => {
+                  if (library.isEnabled) await disableLibrary(library.id); else await enableLibrary(library.id);
+                  const libraries = await listLibraries(); setState((current) => ({ ...current, libraries }));
+                }}>{library.isEnabled ? "無効化" : "有効化"}</button>
+                <button className="ui-mini-button text-destructive" onClick={async () => {
+                  if (!confirm(`「${library.name}」の登録を解除しますか？\n元画像は削除されません。`)) return;
+                  await removeLibrary(library.id);
+                  const libraries = await listLibraries();
+                  setState((current) => ({ ...current, libraries, selectedLibraryId: current.selectedLibraryId === library.id ? (libraries[0]?.id ?? null) : current.selectedLibraryId, selectedFolderPath: "", detailOpen: false, detailAsset: null }));
+                }}>登録解除</button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FoldersPanel() {
+  const { state, setState } = useApp();
+  const { data: folders = [] } = useQuery({ queryKey: ["folderTree", state.selectedLibraryId], queryFn: () => getFolderTree(state.selectedLibraryId!), enabled: !!state.selectedLibraryId, staleTime: Infinity });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const roots = folders.filter((folder) => !folder.parentPath);
+  const children = (path: string) => folders.filter((folder) => folder.parentPath === path);
+
+  const renderFolder = (folder: FolderDTO, depth: number): React.ReactNode => {
+    const nested = children(folder.path);
+    const open = expanded.has(folder.path);
+    const selected = state.selectedFolderPath === folder.path;
+    const name = folder.path.split(/[\\/]/).pop() || folder.path;
+    return (
+      <div key={folder.path}>
+        <div className={`flex items-center rounded-lg ${selected ? "bg-primary/10" : "hover:bg-accent/50"}`} style={{ paddingLeft: depth * 10 }}>
+          <button className="w-7 h-8 text-[10px] flex-shrink-0" onClick={() => setExpanded((current) => { const next = new Set(current); if (next.has(folder.path)) next.delete(folder.path); else next.add(folder.path); return next; })} disabled={!nested.length}>{nested.length ? (open ? "▼" : "▶") : ""}</button>
+          <button className="min-w-0 flex-1 h-8 text-left text-[11px] truncate pr-2" title={folder.path} onClick={() => setState((current) => ({ ...current, selectedFolderPath: folder.path }))}>{name}</button>
+        </div>
+        {open && nested.map((item) => renderFolder(item, depth + 1))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="pb-3">
+      <PanelTitle title="フォルダー" description="選択したフォルダー以下をまとめて表示します。" />
+      <div className="px-2">
+        <button className={`w-full h-9 px-2.5 text-left rounded-lg text-xs ${!state.selectedFolderPath ? "bg-primary/10 font-medium" : "hover:bg-accent/50"}`} onClick={() => setState((current) => ({ ...current, selectedFolderPath: "" }))}>すべての画像</button>
+        <div className="mt-1">{roots.map((folder) => renderFolder(folder, 0))}</div>
+      </div>
+    </div>
+  );
+}
+
+function TagsPanel() {
+  const queryClient = useQueryClient();
+  const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("#6366f1");
+  return (
+    <div className="pb-3">
+      <PanelTitle title="タグ" description="画像の分類用タグを管理します。" />
+      <div className="px-3 space-y-3">
+        <div className="grid grid-cols-[minmax(0,1fr)_36px_auto] gap-2">
+          <input className="ui-input min-w-0" value={name} onChange={(event) => setName(event.target.value)} placeholder="タグ名" />
+          <input type="color" className="w-9 h-9 rounded-lg border border-border bg-transparent" value={color} onChange={(event) => setColor(event.target.value)} />
+          <button className="ui-primary-button" onClick={async () => { if (!name.trim()) return; await createTag(name.trim(), color); setName(""); await queryClient.invalidateQueries({ queryKey: ["tags"] }); }}>追加</button>
+        </div>
+        <div className="space-y-1">
+          {tags.map((tag) => <div key={tag.id} className="min-h-9 px-2.5 rounded-lg flex items-center gap-2 hover:bg-accent/50"><span className="w-3 h-3 rounded-full" style={{ backgroundColor: tag.color }} /><span className="text-xs min-w-0 flex-1 truncate">{tag.name}</span><button className="text-[11px] text-muted-foreground hover:text-destructive" onClick={async () => { await deleteTag(tag.id); await queryClient.invalidateQueries({ queryKey: ["tags"] }); }}>削除</button></div>)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PostRecordsPanel() {
+  const queryClient = useQueryClient();
+  const { data: records = [] } = useQuery({ queryKey: ["postRecords"], queryFn: () => listPostRecords(0, 100), staleTime: Infinity });
+  const [targets, setTargets] = useState<PostTargetDTO[]>([]);
+  const [accounts, setAccounts] = useState<PostAccountDTO[]>([]);
+  const [showSettings, setShowSettings] = useState(false);
+  const [targetName, setTargetName] = useState("");
+  const [targetKind, setTargetKind] = useState("pixiv");
+  const [accountTargetId, setAccountTargetId] = useState(0);
+  const [accountName, setAccountName] = useState("");
+  const [accountIdentifier, setAccountIdentifier] = useState("");
+
+  const reloadSettings = async () => {
+    const [nextTargets, nextAccounts] = await Promise.all([listPostTargets(), listPostAccounts()]);
+    setTargets(nextTargets ?? []); setAccounts(nextAccounts ?? []);
+    setAccountTargetId((current) => current || nextTargets?.[0]?.id || 0);
+  };
+  useEffect(() => { void reloadSettings(); }, []);
+
+  return (
+    <div className="pb-3">
+      <PanelTitle title="投稿記録" description="どの画像を、どの投稿先・アカウントへ登録したか確認します。" />
+      <div className="px-3 space-y-3">
+        <div className="rounded-xl border border-border bg-muted/20 p-3 text-[11px] leading-relaxed text-muted-foreground">記録の追加は、画像を選択して右の詳細パネル、または複数選択時の「＋ 投稿記録」から行えます。</div>
+        <div className="space-y-2">
+          {records.map((record) => (
+            <div key={record.id} className="rounded-xl border border-border bg-muted/15 p-2.5">
+              <div className="flex items-start gap-2">
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-medium truncate">{record.targetName} · {record.accountDisplay}</p>
+                  <p className="mt-0.5 text-[10px] text-muted-foreground truncate">{record.title || "投稿記録"} · 画像{record.assetIds.length}件</p>
+                </div>
+                <button className="text-[10px] text-muted-foreground hover:text-destructive" onClick={async () => { if (!confirm("この投稿記録を削除しますか？")) return; await deletePost(record.id); await queryClient.invalidateQueries({ queryKey: ["postRecords"] }); }}>削除</button>
+              </div>
+              <p className="mt-1.5 text-[10px] text-muted-foreground">{record.publishedAt ? new Date(record.publishedAt).toLocaleString("ja-JP") : ""}</p>
+              {record.externalPostId && <p className="mt-1 text-[10px] text-primary break-all">{record.externalPostId}</p>}
+            </div>
+          ))}
+          {records.length === 0 && <p className="py-4 text-xs text-center text-muted-foreground">投稿記録はまだありません</p>}
+        </div>
+
+        <button className="ui-secondary-button w-full justify-between" onClick={() => setShowSettings((value) => !value)}><span>投稿先・アカウント設定</span><span>{showSettings ? "▲" : "▼"}</span></button>
+        {showSettings && (
+          <div className="space-y-4 rounded-xl border border-border p-3">
+            <div className="space-y-2">
+              <p className="ui-label">投稿先</p>
+              <div className="grid grid-cols-[minmax(0,1fr)_90px_auto] gap-1.5">
+                <input className="ui-input min-w-0" value={targetName} onChange={(event) => setTargetName(event.target.value)} placeholder="Pixivなど" />
+                <select className="ui-input" value={targetKind} onChange={(event) => setTargetKind(event.target.value)}><option value="pixiv">Pixiv</option><option value="twitter">X</option><option value="misskey">Misskey</option><option value="bluesky">Bluesky</option><option value="other">その他</option></select>
+                <button className="ui-primary-button" onClick={async () => { if (!targetName.trim()) return; await createPostTarget(targetName.trim(), targetKind); setTargetName(""); await reloadSettings(); }}>追加</button>
+              </div>
+              {targets.map((target) => <div key={target.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{target.name} ({target.kind})</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { await deletePostTarget(target.id); await reloadSettings(); }}>削除</button></div>)}
+            </div>
+            <div className="space-y-2 border-t border-border pt-3">
+              <p className="ui-label">アカウント</p>
+              <select className="ui-input w-full" value={accountTargetId} onChange={(event) => setAccountTargetId(Number(event.target.value))}>{targets.map((target) => <option key={target.id} value={target.id}>{target.name}</option>)}</select>
+              <input className="ui-input w-full" value={accountName} onChange={(event) => setAccountName(event.target.value)} placeholder="表示名" />
+              <div className="flex gap-1.5"><input className="ui-input min-w-0 flex-1" value={accountIdentifier} onChange={(event) => setAccountIdentifier(event.target.value)} placeholder="@username / ID" /><button className="ui-primary-button" onClick={async () => { if (!accountTargetId || !accountName.trim()) return; await createPostAccount(accountTargetId, accountName.trim(), accountIdentifier.trim()); setAccountName(""); setAccountIdentifier(""); await reloadSettings(); }}>追加</button></div>
+              {accounts.map((account) => <div key={account.id} className="flex items-center gap-2 text-[11px]"><span className="min-w-0 flex-1 truncate">{account.displayName}{account.accountIdentifier ? ` · ${account.accountIdentifier}` : ""}</span><button className="text-muted-foreground hover:text-destructive" onClick={async () => { await deletePostAccount(account.id); await reloadSettings(); }}>削除</button></div>)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SettingsPanel() {
+  const [extensions, setExtensions] = useState<string[]>([]);
+  const [extension, setExtension] = useState("");
+  const [conflictPolicy, setConflictPolicy] = useState("abort");
+  useEffect(() => {
+    void getSupportedExtensions().then((items) => setExtensions(items ?? []));
+    void getSetting("conflictPolicy").then((value) => { if (value) setConflictPolicy(value.replace(/"/g, "")); });
+  }, []);
+  return (
+    <div className="pb-3">
+      <PanelTitle title="設定" description="読み込み対象やファイル操作を設定します。" />
+      <div className="px-3 space-y-4">
+        <section className="space-y-2">
+          <p className="ui-label">対応拡張子</p>
+          <div className="flex flex-wrap gap-1">{extensions.map((item) => <span key={item} className="h-7 px-2 rounded-full bg-muted border border-border text-[10px] inline-flex items-center gap-1">{item}<button onClick={async () => { const next = extensions.filter((value) => value !== item); await setSupportedExtensions(next); setExtensions(next); }}>×</button></span>)}</div>
+          <div className="flex gap-2"><input className="ui-input min-w-0 flex-1" value={extension} onChange={(event) => setExtension(event.target.value)} placeholder="例: .raw" /><button className="ui-primary-button" onClick={async () => { const nextValue = extension.trim().toLowerCase(); if (!nextValue || extensions.includes(nextValue)) return; const next = [...extensions, nextValue]; await setSupportedExtensions(next); setExtensions(next); setExtension(""); }}>追加</button></div>
+        </section>
+        <section className="space-y-2 border-t border-border pt-3">
+          <p className="ui-label">同名ファイルがある場合</p>
+          <select className="ui-input w-full" value={conflictPolicy} onChange={async (event) => { setConflictPolicy(event.target.value); await setSetting("conflictPolicy", JSON.stringify(event.target.value)); }}><option value="abort">処理を中止</option><option value="skip">既存を残してスキップ</option><option value="rename">自動で別名</option></select>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export function ToolbarV2() {
+  const { state, setState } = useApp();
+  const [search, setSearch] = useState(state.searchQuery);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const library = state.libraries.find((item) => item.id === state.selectedLibraryId);
+  const folderName = state.selectedFolderPath.split(/[\\/]/).pop() || "";
+  useEffect(() => setSearch(state.searchQuery), [state.searchQuery]);
+  useEffect(() => () => timer.current && clearTimeout(timer.current), []);
+
+  const updateSearch = (value: string) => {
+    setSearch(value);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setState((current) => ({ ...current, searchQuery: value })), 250);
+  };
+
+  const hasFilters = !!(state.selectedFolderPath || state.searchQuery || state.filterStatusLabel || state.filterRating);
+  return (
+    <header className="toolbar-v2 border-b border-border bg-card/80 flex-shrink-0">
+      <div className="toolbar-primary-row">
+        <button className="ui-icon-button" onClick={() => setState((current) => ({ ...current, sidebarOpen: !current.sidebarOpen }))} aria-label="サイドバー切り替え">☰</button>
+        <div className="toolbar-library min-w-0"><p className="text-[10px] text-muted-foreground">表示中</p><p className="text-xs font-medium truncate" title={library?.rootPath}>{library?.name ?? "未選択"}</p></div>
+        <div className="relative min-w-0 flex-1">
+          <input className="ui-input w-full pl-3" value={search} onChange={(event) => updateSearch(event.target.value)} placeholder="ファイル名・メモを検索…" />
+        </div>
+      </div>
+
+      <div className="toolbar-controls-row">
+        <select className="ui-input" value={state.sortBy} onChange={(event) => setState((current) => ({ ...current, sortBy: event.target.value }))}><option value="modifiedAtFs">更新日時</option><option value="created">作成日時</option><option value="name">ファイル名</option><option value="size">サイズ</option><option value="rating">評価</option><option value="status">状態</option></select>
+        <button className="ui-secondary-button" onClick={() => setState((current) => ({ ...current, sortDesc: !current.sortDesc }))}>{state.sortDesc ? "降順 ↓" : "昇順 ↑"}</button>
+        <select className="ui-input" value={state.filterStatusLabel} onChange={(event) => setState((current) => ({ ...current, filterStatusLabel: event.target.value }))}><option value="">状態: すべて</option><option value="unsorted">未整理</option><option value="reviewed">確認済み</option><option value="candidate">候補</option><option value="published">公開済み</option></select>
+        <select className="ui-input" value={state.filterRating} onChange={(event) => setState((current) => ({ ...current, filterRating: Number(event.target.value) }))}><option value={0}>評価: すべて</option>{[1,2,3,4,5].map((rating) => <option key={rating} value={rating}>{"★".repeat(rating)}</option>)}</select>
+        <div className="ui-segmented">{[[120,"小"],[180,"中"],[260,"大"]].map(([value,label]) => <button key={value} onClick={() => setState((current) => ({ ...current, thumbnailSize: Number(value) }))} className={state.thumbnailSize === Number(value) ? "active" : ""}>{label}</button>)}</div>
+        <div className="ui-segmented"><button className={state.viewMode === "grid" ? "active" : ""} onClick={() => setState((current) => ({ ...current, viewMode: "grid" }))}>グリッド</button><button className={state.viewMode === "list" ? "active" : ""} onClick={() => setState((current) => ({ ...current, viewMode: "list" }))}>リスト</button></div>
+        {state.selectedAssets.size > 0 && <span className="ml-auto text-[11px] font-medium text-primary whitespace-nowrap">{state.selectedAssets.size}件選択</span>}
+      </div>
+
+      {hasFilters && (
+        <div className="toolbar-filter-row">
+          <span className="text-[10px] text-muted-foreground">絞り込み</span>
+          {state.selectedFolderPath && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, selectedFolderPath: "" }))}>📁 {folderName} ×</button>}
+          {state.searchQuery && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, searchQuery: "" }))}>検索: {state.searchQuery} ×</button>}
+          {state.filterStatusLabel && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, filterStatusLabel: "" }))}>状態 ×</button>}
+          {state.filterRating > 0 && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, filterRating: 0 }))}>★{state.filterRating} ×</button>}
+          <button className="text-[10px] text-muted-foreground hover:text-foreground" onClick={() => setState((current) => ({ ...current, selectedFolderPath: "", searchQuery: "", filterStatusLabel: "", filterRating: 0 }))}>すべて解除</button>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/frontend/src/components/PostRecordModal.tsx
+++ b/frontend/src/components/PostRecordModal.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  createPostAccount,
+  createPostRecord,
+  createPostTarget,
+  listPostAccounts,
+  listPostTargets,
+} from "../api/client";
+import type { PostAccountDTO, PostTargetDTO } from "../api/client";
+
+interface PostRecordModalProps {
+  assetIds: number[];
+  defaultTitle?: string;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved }: PostRecordModalProps) {
+  const [targets, setTargets] = useState<PostTargetDTO[]>([]);
+  const [accounts, setAccounts] = useState<PostAccountDTO[]>([]);
+  const [targetId, setTargetId] = useState(0);
+  const [accountId, setAccountId] = useState(0);
+  const [title, setTitle] = useState(defaultTitle);
+  const [externalPostId, setExternalPostId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showQuickTarget, setShowQuickTarget] = useState(false);
+  const [showQuickAccount, setShowQuickAccount] = useState(false);
+  const [newTargetName, setNewTargetName] = useState("");
+  const [newTargetKind, setNewTargetKind] = useState("twitter");
+  const [newAccountDisplay, setNewAccountDisplay] = useState("");
+  const [newAccountIdentifier, setNewAccountIdentifier] = useState("");
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    void Promise.all([listPostTargets(), listPostAccounts()]).then(([loadedTargets, loadedAccounts]) => {
+      setTargets(loadedTargets ?? []);
+      setAccounts(loadedAccounts ?? []);
+      const firstTarget = loadedTargets?.[0]?.id ?? 0;
+      setTargetId(firstTarget);
+      const firstAccount = loadedAccounts?.find((account) => account.postTargetId === firstTarget)?.id ?? 0;
+      setAccountId(firstAccount);
+      if (!loadedTargets?.length) setShowQuickTarget(true);
+      else if (!firstAccount) setShowQuickAccount(true);
+    });
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !busy) onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [busy, onClose]);
+
+  const filteredAccounts = useMemo(
+    () => accounts.filter((account) => account.postTargetId === targetId && account.isActive),
+    [accounts, targetId]
+  );
+
+  useEffect(() => {
+    if (filteredAccounts.some((account) => account.id === accountId)) return;
+    setAccountId(filteredAccounts[0]?.id ?? 0);
+    setShowQuickAccount(filteredAccounts.length === 0 && targetId > 0);
+  }, [accountId, filteredAccounts, targetId]);
+
+  const quickCreateTarget = async () => {
+    if (!newTargetName.trim()) return;
+    setError(null);
+    const target = await createPostTarget(newTargetName.trim(), newTargetKind);
+    if (!target) {
+      setError("投稿先を追加できませんでした。");
+      return;
+    }
+    setTargets((current) => [...current, target]);
+    setTargetId(target.id);
+    setNewTargetName("");
+    setShowQuickTarget(false);
+    setShowQuickAccount(true);
+  };
+
+  const quickCreateAccount = async () => {
+    if (!targetId || !newAccountDisplay.trim()) return;
+    setError(null);
+    const account = await createPostAccount(targetId, newAccountDisplay.trim(), newAccountIdentifier.trim());
+    if (!account) {
+      setError("アカウントを追加できませんでした。");
+      return;
+    }
+    setAccounts((current) => [...current, account]);
+    setAccountId(account.id);
+    setNewAccountDisplay("");
+    setNewAccountIdentifier("");
+    setShowQuickAccount(false);
+  };
+
+  const save = async () => {
+    if (!targetId || !accountId || assetIds.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const record = await createPostRecord({
+        assetIds,
+        targetId,
+        accountId,
+        title: title.trim(),
+        externalPostId: externalPostId.trim(),
+      });
+      if (!record) throw new Error("投稿記録を保存できませんでした");
+      onSaved?.();
+      onClose();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : String(saveError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[110] bg-black/65 backdrop-blur-sm flex items-center justify-center p-4" onMouseDown={(event) => {
+      if (event.currentTarget === event.target && !busy) onClose();
+    }}>
+      <div className="w-full max-w-xl max-h-[calc(100dvh-32px)] overflow-hidden rounded-2xl border border-border bg-card shadow-2xl" role="dialog" aria-modal="true" aria-label="投稿記録を追加">
+        <div className="h-14 px-4 border-b border-border flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">投稿記録を追加</h2>
+            <p className="text-[11px] text-muted-foreground truncate">選択した{assetIds.length}件の画像を、どこへ投稿したか記録します。</p>
+          </div>
+          <button onClick={onClose} disabled={busy} className="ui-icon-button text-lg" aria-label="閉じる">×</button>
+        </div>
+
+        <div className="overflow-auto p-4 space-y-4 max-h-[calc(100dvh-154px)]">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="space-y-1.5">
+              <span className="ui-label">投稿先</span>
+              <select
+                value={targetId}
+                onChange={(event) => setTargetId(Number(event.target.value))}
+                className="ui-input w-full"
+              >
+                <option value={0}>投稿先を選択</option>
+                {targets.map((target) => <option key={target.id} value={target.id}>{target.name} ({target.kind})</option>)}
+              </select>
+            </label>
+
+            <label className="space-y-1.5">
+              <span className="ui-label">アカウント</span>
+              <select
+                value={accountId}
+                onChange={(event) => setAccountId(Number(event.target.value))}
+                className="ui-input w-full"
+                disabled={!targetId}
+              >
+                <option value={0}>アカウントを選択</option>
+                {filteredAccounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.displayName}{account.accountIdentifier ? ` (${account.accountIdentifier})` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button className="ui-secondary-button" onClick={() => setShowQuickTarget((value) => !value)}>＋ 投稿先を追加</button>
+            <button className="ui-secondary-button" onClick={() => setShowQuickAccount((value) => !value)} disabled={!targetId}>＋ アカウントを追加</button>
+          </div>
+
+          {showQuickTarget && (
+            <div className="rounded-xl border border-border bg-muted/25 p-3 space-y-2">
+              <p className="text-xs font-medium">投稿先をその場で追加</p>
+              <div className="grid grid-cols-[minmax(0,1fr)_120px_auto] gap-2">
+                <input className="ui-input min-w-0" value={newTargetName} onChange={(event) => setNewTargetName(event.target.value)} placeholder="例: Pixiv" />
+                <select className="ui-input" value={newTargetKind} onChange={(event) => setNewTargetKind(event.target.value)}>
+                  <option value="twitter">X</option>
+                  <option value="pixiv">Pixiv</option>
+                  <option value="misskey">Misskey</option>
+                  <option value="bluesky">Bluesky</option>
+                  <option value="other">その他</option>
+                </select>
+                <button className="ui-primary-button" onClick={() => void quickCreateTarget()}>追加</button>
+              </div>
+            </div>
+          )}
+
+          {showQuickAccount && targetId > 0 && (
+            <div className="rounded-xl border border-border bg-muted/25 p-3 space-y-2">
+              <p className="text-xs font-medium">この投稿先のアカウントを追加</p>
+              <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
+                <input className="ui-input min-w-0" value={newAccountDisplay} onChange={(event) => setNewAccountDisplay(event.target.value)} placeholder="表示名" />
+                <input className="ui-input min-w-0" value={newAccountIdentifier} onChange={(event) => setNewAccountIdentifier(event.target.value)} placeholder="@username / ID (任意)" />
+                <button className="ui-primary-button" onClick={() => void quickCreateAccount()}>追加</button>
+              </div>
+            </div>
+          )}
+
+          <label className="block space-y-1.5">
+            <span className="ui-label">記録名 <span className="font-normal text-muted-foreground">(任意)</span></span>
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="ui-input w-full"
+              placeholder="例: 2026/09/04 Pixiv投稿"
+            />
+          </label>
+
+          <label className="block space-y-1.5">
+            <span className="ui-label">投稿URL / 外部ID <span className="font-normal text-muted-foreground">(任意)</span></span>
+            <input
+              value={externalPostId}
+              onChange={(event) => setExternalPostId(event.target.value)}
+              className="ui-input w-full"
+              placeholder="投稿ページURLや作品IDなど"
+            />
+            <p className="text-[11px] text-muted-foreground">後から「どこに投稿した画像か」を確認しやすくするための補助情報です。</p>
+          </label>
+
+          {error && <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>}
+        </div>
+
+        <div className="min-h-16 px-4 py-3 border-t border-border flex items-center justify-between gap-3 bg-card">
+          <p className="text-[11px] text-muted-foreground">画像ファイル自体は変更・移動されません。</p>
+          <div className="flex items-center gap-2">
+            <button className="ui-secondary-button" onClick={onClose} disabled={busy}>キャンセル</button>
+            <button className="ui-primary-button min-w-28" onClick={() => void save()} disabled={busy || !targetId || !accountId || assetIds.length === 0}>
+              {busy ? "保存中…" : "投稿記録を保存"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/ViewerGridV2.tsx
+++ b/frontend/src/components/ViewerGridV2.tsx
@@ -10,6 +10,7 @@ import { ImageViewerModal } from "./ImageViewerModal";
 
 const PAGE_SIZE = 100;
 const GAP = 10;
+const GRID_PADDING = 24;
 
 interface ViewerGridV2Props {
   onSelectAsset: (asset: AssetDTO, multi: boolean, range: boolean) => void;
@@ -25,9 +26,10 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
-    const observer = new ResizeObserver(() => setContainerWidth(element.clientWidth));
+    const updateWidth = () => setContainerWidth(Math.max(0, element.clientWidth - GRID_PADDING));
+    const observer = new ResizeObserver(updateWidth);
     observer.observe(element);
-    setContainerWidth(element.clientWidth);
+    updateWidth();
     return () => observer.disconnect();
   }, []);
 

--- a/frontend/src/components/ViewerGridV2.tsx
+++ b/frontend/src/components/ViewerGridV2.tsx
@@ -1,0 +1,345 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import type { AssetDTO, AssetListRequest } from "../api/client";
+import { listAssets } from "../api/client";
+import { useApp } from "../App";
+import { formatFileSize } from "../utils/format";
+import { MemoryImage } from "./MemoryImage";
+import { ImageViewerModal } from "./ImageViewerModal";
+
+const PAGE_SIZE = 100;
+const GAP = 10;
+
+interface ViewerGridV2Props {
+  onSelectAsset: (asset: AssetDTO, multi: boolean, range: boolean) => void;
+  onAssetsLoaded: (ids: number[]) => void;
+}
+
+export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Props) {
+  const { state } = useApp();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [previewAsset, setPreviewAsset] = useState<AssetDTO | null>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    const observer = new ResizeObserver(() => setContainerWidth(element.clientWidth));
+    observer.observe(element);
+    setContainerWidth(element.clientWidth);
+    return () => observer.disconnect();
+  }, []);
+
+  const buildQuery = useCallback((offset: number): AssetListRequest => ({
+    libraryId: state.selectedLibraryId ?? 0,
+    search: state.searchQuery || undefined,
+    folderPath: state.selectedFolderPath || undefined,
+    recurse: !!state.selectedFolderPath,
+    sortBy: state.sortBy || undefined,
+    sortDesc: state.sortDesc,
+    statusLabel: state.filterStatusLabel || undefined,
+    rating: state.filterRating || undefined,
+    offset,
+    limit: PAGE_SIZE,
+  }), [
+    state.filterRating,
+    state.filterStatusLabel,
+    state.searchQuery,
+    state.selectedFolderPath,
+    state.selectedLibraryId,
+    state.sortBy,
+    state.sortDesc,
+  ]);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: [
+      "assets",
+      state.selectedLibraryId,
+      state.selectedFolderPath,
+      state.searchQuery,
+      state.sortBy,
+      state.sortDesc,
+      state.filterStatusLabel,
+      state.filterRating,
+    ],
+    queryFn: async ({ pageParam = 0 }) => {
+      const result = await listAssets(buildQuery(Number(pageParam)));
+      return result ?? { assets: [], totalCount: 0 };
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((sum, page) => sum + page.assets.length, 0);
+      const total = allPages[0]?.totalCount ?? 0;
+      return lastPage.assets.length === 0 || loaded >= total ? undefined : loaded;
+    },
+    enabled: !!state.selectedLibraryId,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  const assets = useMemo(() => data?.pages.flatMap((page) => page.assets) ?? [], [data]);
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  useEffect(() => onAssetsLoaded(assets.map((asset) => asset.id)), [assets, onAssetsLoaded]);
+
+  const columns = containerWidth > 0
+    ? Math.max(1, Math.floor((containerWidth + GAP) / (state.thumbnailSize + GAP)))
+    : 4;
+  const rowCount = Math.ceil(assets.length / columns);
+
+  const virtualizer = useVirtualizer({
+    count: state.viewMode === "grid" ? rowCount : assets.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => state.viewMode === "grid" ? state.thumbnailSize + GAP : 60,
+    overscan: 1,
+  });
+  const virtualItems = virtualizer.getVirtualItems();
+
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    const last = virtualItems[virtualItems.length - 1];
+    const maximum = state.viewMode === "grid" ? rowCount : assets.length;
+    if (last && last.index >= maximum - 3) void fetchNextPage();
+  }, [assets.length, fetchNextPage, hasNextPage, isFetchingNextPage, rowCount, state.viewMode, virtualItems]);
+
+  const previewIndex = previewAsset ? assets.findIndex((asset) => asset.id === previewAsset.id) : -1;
+
+  if (!state.selectedLibraryId) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center space-y-2">
+          <p className="text-sm font-semibold">表示するライブラリを選択してください</p>
+          <p className="text-xs text-muted-foreground">左側のライブラリから画像フォルダーを選べます。</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-2 p-8">
+        <p className="text-sm font-semibold text-destructive">画像一覧を読み込めませんでした</p>
+        <p className="max-w-lg text-center text-xs text-muted-foreground break-all">{String(error)}</p>
+      </div>
+    );
+  }
+
+  const hasFilters = !!(state.selectedFolderPath || state.searchQuery || state.filterStatusLabel || state.filterRating > 0);
+
+  return (
+    <>
+      <div ref={containerRef} className="flex-1 min-w-0 overflow-auto bg-background p-3">
+        {state.viewMode === "grid" ? (
+          <div style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}>
+            {virtualItems.map((virtualRow) => {
+              const startIndex = virtualRow.index * columns;
+              const rowAssets = assets.slice(startIndex, startIndex + columns);
+              return (
+                <div
+                  key={virtualRow.key}
+                  style={{
+                    position: "absolute",
+                    insetInline: 0,
+                    top: 0,
+                    height: virtualRow.size,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <div style={{ display: "grid", gridTemplateColumns: `repeat(${columns}, ${state.thumbnailSize}px)`, gap: GAP }}>
+                    {rowAssets.map((asset) => (
+                      <GridCard
+                        key={asset.id}
+                        asset={asset}
+                        size={state.thumbnailSize}
+                        selected={state.selectedAssets.has(asset.id)}
+                        onSelect={onSelectAsset}
+                        onPreview={() => setPreviewAsset(asset)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}>
+            {virtualItems.map((item) => {
+              const asset = assets[item.index];
+              if (!asset) return null;
+              return (
+                <ListRow
+                  key={asset.id}
+                  asset={asset}
+                  selected={state.selectedAssets.has(asset.id)}
+                  onSelect={onSelectAsset}
+                  onPreview={() => setPreviewAsset(asset)}
+                  style={{
+                    position: "absolute",
+                    insetInline: 0,
+                    top: 0,
+                    height: item.size,
+                    transform: `translateY(${item.start}px)`,
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-20 gap-3 text-sm text-muted-foreground">
+            <div className="w-7 h-7 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" />
+            画像一覧を読み込んでいます…
+          </div>
+        )}
+
+        {isFetchingNextPage && (
+          <div className="flex items-center justify-center py-4 gap-2 text-xs text-muted-foreground">
+            <div className="w-4 h-4 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" />
+            続きを読み込み中… {assets.length.toLocaleString()} / {totalCount.toLocaleString()}件
+          </div>
+        )}
+
+        {!isLoading && assets.length === 0 && (
+          <div className="min-h-[55vh] flex items-center justify-center">
+            <div className="max-w-sm rounded-2xl border border-dashed border-border p-8 text-center">
+              <p className="text-sm font-semibold">{hasFilters ? "条件に一致する画像がありません" : "画像が見つかりません"}</p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {hasFilters ? "上部の絞り込み条件を解除して確認してください。" : "対象フォルダーを再スキャンしてください。"}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {previewAsset && (
+        <ImageViewerModal
+          asset={previewAsset}
+          onClose={() => setPreviewAsset(null)}
+          onPrev={() => previewIndex > 0 && setPreviewAsset(assets[previewIndex - 1])}
+          onNext={() => previewIndex >= 0 && previewIndex < assets.length - 1 && setPreviewAsset(assets[previewIndex + 1])}
+          hasPrev={previewIndex > 0}
+          hasNext={previewIndex >= 0 && previewIndex < assets.length - 1}
+        />
+      )}
+    </>
+  );
+}
+
+function GridCard({
+  asset,
+  size,
+  selected,
+  onSelect,
+  onPreview,
+}: {
+  asset: AssetDTO;
+  size: number;
+  selected: boolean;
+  onSelect: (asset: AssetDTO, multi: boolean, range: boolean) => void;
+  onPreview: () => void;
+}) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded-xl border bg-muted group transition-all ${selected ? "border-primary ring-2 ring-primary/30 shadow-lg" : "border-border/60 hover:border-border hover:shadow-lg"}`}
+      style={{ width: size, height: size }}
+      onClick={(event) => onSelect(asset, event.ctrlKey || event.metaKey, event.shiftKey)}
+      onDoubleClick={(event) => { event.preventDefault(); onPreview(); }}
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          onPreview();
+        }
+      }}
+      title={`${asset.fileName}\nダブルクリックまたはEnterで大きく表示`}
+    >
+      <MemoryImage
+        filePath={asset.filePath}
+        modifiedAtFs={asset.modifiedAtFs}
+        sourceWidth={asset.width}
+        sourceHeight={asset.height}
+        width={size}
+        height={size}
+        fit="cover"
+        alt={asset.fileName}
+      />
+      <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/85 via-black/25 to-transparent pointer-events-none" />
+      <div className="absolute inset-x-0 bottom-0 px-2.5 py-2 pointer-events-none">
+        <p className="truncate text-[11px] font-medium text-white drop-shadow">{asset.fileName}</p>
+        <p className="mt-0.5 text-[10px] text-white/60">{formatFileSize(asset.fileSize)}</p>
+      </div>
+
+      <button
+        onClick={(event) => { event.stopPropagation(); onPreview(); }}
+        className="absolute top-2 right-2 min-w-16 h-8 px-2 rounded-lg border border-white/20 bg-black/65 text-[11px] font-medium text-white opacity-90 hover:bg-black/80 focus:opacity-100"
+        aria-label={`${asset.fileName} を大きく表示`}
+      >
+        ⛶ 拡大
+      </button>
+
+      {selected && (
+        <div className="absolute top-2 left-2 w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-[11px] shadow">✓</div>
+      )}
+      {asset.isFavorite && !selected && <div className="absolute top-2 left-2 text-yellow-400 drop-shadow">★</div>}
+      {asset.rating > 0 && <div className="absolute bottom-10 right-2 text-[10px] text-yellow-400 drop-shadow">{"★".repeat(asset.rating)}</div>}
+    </div>
+  );
+}
+
+function ListRow({
+  asset,
+  selected,
+  onSelect,
+  onPreview,
+  style,
+}: {
+  asset: AssetDTO;
+  selected: boolean;
+  onSelect: (asset: AssetDTO, multi: boolean, range: boolean) => void;
+  onPreview: () => void;
+  style: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={style}
+      className={`flex items-center gap-3 px-2.5 rounded-lg border border-transparent ${selected ? "bg-primary/10 border-primary/25" : "hover:bg-accent/50"}`}
+      onClick={(event) => onSelect(asset, event.ctrlKey || event.metaKey, event.shiftKey)}
+      onDoubleClick={onPreview}
+    >
+      <MemoryImage
+        filePath={asset.filePath}
+        modifiedAtFs={asset.modifiedAtFs}
+        sourceWidth={asset.width}
+        sourceHeight={asset.height}
+        width={44}
+        height={44}
+        fit="cover"
+        alt={asset.fileName}
+        className="rounded-lg flex-shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium">{asset.fileName}</p>
+        <p className="truncate text-[11px] text-muted-foreground">{asset.folderPath}</p>
+      </div>
+      <span className="text-[11px] text-muted-foreground tabular-nums flex-shrink-0">{formatFileSize(asset.fileSize)}</span>
+      <button
+        onClick={(event) => { event.stopPropagation(); onPreview(); }}
+        className="ui-secondary-button flex-shrink-0"
+      >
+        ⛶ 大きく表示
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,6 +21,13 @@
   --input: 240 3.7% 15.9%;
   --ring: 240 4.9% 83.9%;
   --radius: 0.625rem;
+
+  --sidebar-width: 15rem;
+  --detail-width: clamp(19rem, 24vw, 23rem);
+  --control-height: 2rem;
+  --control-radius: 0.5rem;
+  --ui-font: 0.75rem;
+  --ui-font-small: 0.6875rem;
 }
 
 * {
@@ -57,12 +64,258 @@ button:not(:disabled) {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
+}
+
+.app-shell {
+  min-width: 720px;
+}
+
+.app-sidebar {
+  width: var(--sidebar-width);
+  min-width: 13.5rem;
+  max-width: 17rem;
+}
+
+.app-detail-panel {
+  width: var(--detail-width);
+  min-width: 19rem;
+  max-width: 23rem;
+  flex-shrink: 0;
+}
+
+.ui-input {
+  min-height: var(--control-height);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--control-radius);
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  padding: 0.375rem 0.625rem;
+  font-size: var(--ui-font-small);
+  line-height: 1.25;
+}
+
+.ui-input::placeholder {
+  color: hsl(var(--muted-foreground) / 0.65);
+}
+
+.ui-label {
+  display: block;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--ui-font-small);
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.ui-primary-button,
+.ui-secondary-button,
+.ui-mini-button,
+.ui-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--control-radius);
+  white-space: nowrap;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease, opacity 120ms ease;
+}
+
+.ui-primary-button {
+  min-height: var(--control-height);
+  padding: 0.375rem 0.75rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-size: var(--ui-font-small);
+  font-weight: 600;
+}
+
+.ui-primary-button:not(:disabled):hover {
+  opacity: 0.9;
+}
+
+.ui-secondary-button {
+  min-height: var(--control-height);
+  padding: 0.375rem 0.625rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: var(--ui-font-small);
+  font-weight: 500;
+}
+
+.ui-secondary-button:not(:disabled):hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+
+.ui-mini-button {
+  min-height: 1.625rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.625rem;
+}
+
+.ui-mini-button:not(:disabled):hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+
+.ui-icon-button {
+  width: var(--control-height);
+  height: var(--control-height);
+  color: hsl(var(--muted-foreground));
+}
+
+.ui-icon-button:not(:disabled):hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+
+.ui-segmented {
+  height: var(--control-height);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.125rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--control-radius);
+  background: hsl(var(--muted));
+  flex-shrink: 0;
+}
+
+.ui-segmented button {
+  min-width: 2rem;
+  height: 1.5rem;
+  padding: 0 0.5rem;
+  border-radius: 0.375rem;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.625rem;
+}
+
+.ui-segmented button.active {
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.2);
+}
+
+.toolbar-primary-row {
+  min-height: 3rem;
+  display: grid;
+  grid-template-columns: 2rem minmax(7rem, 11rem) minmax(14rem, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem 0.25rem;
+}
+
+.toolbar-controls-row {
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem 0.5rem;
+  overflow-x: auto;
+}
+
+.toolbar-filter-row {
+  min-height: 2rem;
+  padding: 0 0.75rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  max-width: 15rem;
+  min-height: 1.625rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  font-size: 0.625rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.viewer-control {
+  min-width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 0.625rem;
+  background: rgb(24 24 27 / 0.82);
+  color: white;
+}
+
+.viewer-control:hover {
+  background: rgb(39 39 42 / 0.95);
+}
+
+.viewer-nav {
+  position: absolute;
+  top: 50%;
+  z-index: 20;
+  width: 3rem;
+  height: 3rem;
+  transform: translateY(-50%);
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 999px;
+  background: rgb(24 24 27 / 0.72);
+  color: white;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.viewer-nav:hover:not(:disabled) {
+  background: rgb(39 39 42 / 0.95);
+}
+
+@media (max-width: 1080px) {
+  :root {
+    --sidebar-width: 13.5rem;
+    --detail-width: min(22rem, 88vw);
+  }
+
+  .app-detail-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 40;
+    box-shadow: -16px 0 40px rgb(0 0 0 / 0.45);
+  }
+
+  .toolbar-primary-row {
+    grid-template-columns: 2rem minmax(6rem, 9rem) minmax(12rem, 1fr);
+  }
+}
+
+@media (max-width: 820px) {
+  :root {
+    --sidebar-width: 12.5rem;
+  }
+
+  .toolbar-library {
+    display: none;
+  }
+
+  .toolbar-primary-row {
+    grid-template-columns: 2rem minmax(12rem, 1fr);
+  }
 }
 
 ::selection {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,7 +23,7 @@
   --radius: 0.625rem;
 
   --sidebar-width: 15rem;
-  --detail-width: clamp(19rem, 24vw, 23rem);
+  --detail-width: clamp(20.5rem, 25vw, 23rem);
   --control-height: 2rem;
   --control-radius: 0.5rem;
   --ui-font: 0.75rem;
@@ -41,6 +41,7 @@ body,
   width: 100%;
   height: 100%;
   margin: 0;
+  min-width: 0;
 }
 
 body {
@@ -78,7 +79,13 @@ textarea:focus-visible {
 }
 
 .app-shell {
-  min-width: 720px;
+  min-width: 0;
+  width: 100%;
+}
+
+.app-main-region {
+  min-width: 0;
+  isolation: isolate;
 }
 
 .app-sidebar {
@@ -89,13 +96,14 @@ textarea:focus-visible {
 
 .app-detail-panel {
   width: var(--detail-width);
-  min-width: 19rem;
+  min-width: 20.5rem;
   max-width: 23rem;
   flex-shrink: 0;
 }
 
 .ui-input {
   min-height: var(--control-height);
+  min-width: 0;
   border: 1px solid hsl(var(--border));
   border-radius: var(--control-radius);
   background: hsl(var(--muted));
@@ -174,6 +182,7 @@ textarea:focus-visible {
 .ui-icon-button {
   width: var(--control-height);
   height: var(--control-height);
+  flex-shrink: 0;
   color: hsl(var(--muted-foreground));
 }
 
@@ -225,6 +234,12 @@ textarea:focus-visible {
   gap: 0.375rem;
   padding: 0.25rem 0.75rem 0.5rem;
   overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.toolbar-controls-row > * {
+  flex-shrink: 0;
 }
 
 .toolbar-filter-row {
@@ -296,6 +311,8 @@ textarea:focus-visible {
     right: 0;
     bottom: 0;
     z-index: 40;
+    min-width: min(20.5rem, 88vw);
+    max-width: 88vw;
     box-shadow: -16px 0 40px rgb(0 0 0 / 0.45);
   }
 
@@ -309,12 +326,39 @@ textarea:focus-visible {
     --sidebar-width: 12.5rem;
   }
 
+  .app-sidebar {
+    min-width: 11rem;
+  }
+
   .toolbar-library {
     display: none;
   }
 
   .toolbar-primary-row {
-    grid-template-columns: 2rem minmax(12rem, 1fr);
+    grid-template-columns: 2rem minmax(10rem, 1fr);
+  }
+}
+
+@media (max-width: 620px) {
+  .app-sidebar {
+    width: min(11.5rem, 42vw);
+    min-width: 10rem;
+  }
+
+  .app-detail-panel {
+    width: min(21rem, 94vw);
+    min-width: 0;
+    max-width: 94vw;
+  }
+
+  .toolbar-primary-row {
+    padding-inline: 0.5rem;
+    grid-template-columns: 2rem minmax(8rem, 1fr);
+  }
+
+  .toolbar-controls-row,
+  .toolbar-filter-row {
+    padding-inline: 0.5rem;
   }
 }
 

--- a/frontend/src/test/AssetDetailPanel.test.tsx
+++ b/frontend/src/test/AssetDetailPanel.test.tsx
@@ -51,7 +51,7 @@ describe("AssetDetailPanel", () => {
       </QueryClientProvider>
     );
 
-    expect(screen.getByText("freshly-scanned.png")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "freshly-scanned.png" })).toBeInTheDocument();
     expect(screen.getByText("C:\\images\\new\\freshly-scanned.png")).toBeInTheDocument();
     expect(screen.getByTestId("memory-image")).toHaveTextContent("freshly-scanned.png");
   });

--- a/frontend/src/test/AssetDetailPanel.test.tsx
+++ b/frontend/src/test/AssetDetailPanel.test.tsx
@@ -7,21 +7,17 @@ vi.mock("../components/MemoryImage", () => ({
   MemoryImage: ({ alt }: { alt: string }) => <div data-testid="memory-image">{alt}</div>,
 }));
 
-vi.mock("../api/client", async () => {
-  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
-  return {
-    ...actual,
-    getAssetDetail: vi.fn(() => new Promise<null>(() => undefined)),
-    getPostRecordsByAsset: vi.fn(async () => []),
-    listTags: vi.fn(async () => []),
-    setAssetTags: vi.fn(async () => undefined),
-    toggleAssetFavorite: vi.fn(async () => undefined),
-    updateAssetColorLabel: vi.fn(async () => undefined),
-    updateAssetNote: vi.fn(async () => undefined),
-    updateAssetRating: vi.fn(async () => undefined),
-    updateAssetStatus: vi.fn(async () => undefined),
-  };
-});
+vi.mock("../api/client", () => ({
+  getAssetDetail: vi.fn(() => new Promise<null>(() => undefined)),
+  getPostRecordsByAsset: vi.fn(async () => []),
+  listTags: vi.fn(async () => []),
+  setAssetTags: vi.fn(async () => undefined),
+  toggleAssetFavorite: vi.fn(async () => undefined),
+  updateAssetColorLabel: vi.fn(async () => undefined),
+  updateAssetNote: vi.fn(async () => undefined),
+  updateAssetRating: vi.fn(async () => undefined),
+  updateAssetStatus: vi.fn(async () => undefined),
+}));
 
 import { AssetDetailPanel } from "../components/AssetDetailPanel";
 

--- a/frontend/src/test/AssetDetailPanel.test.tsx
+++ b/frontend/src/test/AssetDetailPanel.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../components/MemoryImage", () => ({
 }));
 
 vi.mock("../api/client", () => ({
-  getAssetDetail: vi.fn(() => new Promise<null>(() => undefined)),
+  getAssetDetail: vi.fn(async () => null),
   getPostRecordsByAsset: vi.fn(async () => []),
   listTags: vi.fn(async () => []),
   setAssetTags: vi.fn(async () => undefined),
@@ -40,7 +40,7 @@ const freshlyListedAsset = {
 } as AssetDTO;
 
 describe("AssetDetailPanel", () => {
-  it("詳細APIの応答待ちでも一覧データから基本情報をすぐ表示する", () => {
+  it("詳細APIが未取得でも一覧データから基本情報をすぐ表示する", () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -54,6 +54,5 @@ describe("AssetDetailPanel", () => {
     expect(screen.getByText("freshly-scanned.png")).toBeInTheDocument();
     expect(screen.getByText("C:\\images\\new\\freshly-scanned.png")).toBeInTheDocument();
     expect(screen.getByTestId("memory-image")).toHaveTextContent("freshly-scanned.png");
-    expect(screen.getByTitle("詳細情報を読み込み中")).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/AssetDetailPanel.test.tsx
+++ b/frontend/src/test/AssetDetailPanel.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssetDTO } from "../api/client";
+
+vi.mock("../components/MemoryImage", () => ({
+  MemoryImage: ({ alt }: { alt: string }) => <div data-testid="memory-image">{alt}</div>,
+}));
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getAssetDetail: vi.fn(() => new Promise<null>(() => undefined)),
+    getPostRecordsByAsset: vi.fn(async () => []),
+    listTags: vi.fn(async () => []),
+    setAssetTags: vi.fn(async () => undefined),
+    toggleAssetFavorite: vi.fn(async () => undefined),
+    updateAssetColorLabel: vi.fn(async () => undefined),
+    updateAssetNote: vi.fn(async () => undefined),
+    updateAssetRating: vi.fn(async () => undefined),
+    updateAssetStatus: vi.fn(async () => undefined),
+  };
+});
+
+import { AssetDetailPanel } from "../components/AssetDetailPanel";
+
+const freshlyListedAsset = {
+  id: 101,
+  libraryId: 1,
+  folderPath: "C:\\images\\new",
+  fileName: "freshly-scanned.png",
+  filePath: "C:\\images\\new\\freshly-scanned.png",
+  extension: ".png",
+  fileSize: 2048,
+  modifiedAtFs: "2026-09-04T07:00:00Z",
+  width: 1920,
+  height: 1080,
+  thumbStatus: "none",
+  rating: 0,
+  statusLabel: "unsorted",
+  isFavorite: false,
+  iso: 0,
+} as AssetDTO;
+
+describe("AssetDetailPanel", () => {
+  it("詳細APIの応答待ちでも一覧データから基本情報をすぐ表示する", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <AssetDetailPanel asset={freshlyListedAsset} onClose={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText("freshly-scanned.png")).toBeInTheDocument();
+    expect(screen.getByText("C:\\images\\new\\freshly-scanned.png")).toBeInTheDocument();
+    expect(screen.getByTestId("memory-image")).toHaveTextContent("freshly-scanned.png");
+    expect(screen.getByTitle("詳細情報を読み込み中")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/BulkActionsBar.test.tsx
+++ b/frontend/src/test/BulkActionsBar.test.tsx
@@ -10,6 +10,7 @@ function renderBar(overrides: Partial<React.ComponentProps<typeof BulkActionsBar
     onStatus: vi.fn(),
     onFavorite: vi.fn(),
     onColorLabel: vi.fn(),
+    onPostRecord: vi.fn(),
     onDelete: vi.fn(),
     onClear: vi.fn(),
     ...overrides,
@@ -34,11 +35,12 @@ describe("BulkActionsBar", () => {
     expect(screen.getByText("公開済み")).toBeInTheDocument();
   });
 
-  it("お気に入り・削除・選択解除を表示する", () => {
+  it("お気に入り・投稿記録・削除・選択解除を表示する", () => {
     renderBar();
     expect(screen.getByText("★ お気に入り")).toBeInTheDocument();
+    expect(screen.getByText("＋ 投稿記録")).toBeInTheDocument();
     expect(screen.getByText("一覧から削除")).toBeInTheDocument();
-    expect(screen.getByText("選択を解除")).toBeInTheDocument();
+    expect(screen.getByText("選択解除")).toBeInTheDocument();
   });
 
   it("状態ボタンで内部ステータス値を渡す", async () => {
@@ -49,11 +51,19 @@ describe("BulkActionsBar", () => {
     expect(onStatus).toHaveBeenCalledWith("reviewed");
   });
 
+  it("投稿記録モーダルを開ける", async () => {
+    const onPostRecord = vi.fn();
+    renderBar({ onPostRecord });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("＋ 投稿記録"));
+    expect(onPostRecord).toHaveBeenCalledOnce();
+  });
+
   it("選択解除を実行できる", async () => {
     const onClear = vi.fn();
     renderBar({ onClear });
     const user = userEvent.setup();
-    await user.click(screen.getByText("選択を解除"));
+    await user.click(screen.getByText("選択解除"));
     expect(onClear).toHaveBeenCalledOnce();
   });
 

--- a/internal/commands/post_tracking.go
+++ b/internal/commands/post_tracking.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"log/slog"
+
+	"github.com/kataage/lumine/internal/infrastructure/db"
+)
+
+type PostRecordRequest struct {
+	AssetIDs       []int64 `json:"assetIds"`
+	TargetID       int64   `json:"targetId"`
+	AccountID      int64   `json:"accountId"`
+	Title          string  `json:"title"`
+	ExternalPostID string  `json:"externalPostId"`
+}
+
+type PostRecordDTO struct {
+	ID                int64   `json:"id"`
+	Title             string  `json:"title"`
+	Status            string  `json:"status"`
+	PublishedAt       string  `json:"publishedAt,omitempty"`
+	CreatedAt         string  `json:"createdAt"`
+	UpdatedAt         string  `json:"updatedAt"`
+	AssetIDs          []int64 `json:"assetIds"`
+	TargetID          int64   `json:"targetId"`
+	TargetName        string  `json:"targetName"`
+	TargetKind        string  `json:"targetKind"`
+	AccountID         int64   `json:"accountId"`
+	AccountDisplay    string  `json:"accountDisplay"`
+	AccountIdentifier string  `json:"accountIdentifier"`
+	ExternalPostID    string  `json:"externalPostId,omitempty"`
+}
+
+func toPostRecordDTO(record db.PostRecordView) PostRecordDTO {
+	dto := PostRecordDTO{
+		ID:                record.ID,
+		Title:             record.Title,
+		Status:            record.Status,
+		CreatedAt:         record.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:         record.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+		AssetIDs:          record.AssetIDs,
+		TargetID:          record.TargetID,
+		TargetName:        record.TargetName,
+		TargetKind:        record.TargetKind,
+		AccountID:         record.AccountID,
+		AccountDisplay:    record.AccountDisplay,
+		AccountIdentifier: record.AccountIdentifier,
+		ExternalPostID:    record.ExternalPostID,
+	}
+	if record.PublishedAt != nil {
+		dto.PublishedAt = record.PublishedAt.Format("2006-01-02T15:04:05Z")
+	}
+	return dto
+}
+
+func (c *AppCommands) CreatePostRecord(req PostRecordRequest) *PostRecordDTO {
+	postID, err := c.postRepo.CreateTrackingRecord(
+		req.Title,
+		req.AssetIDs,
+		req.TargetID,
+		req.AccountID,
+		req.ExternalPostID,
+	)
+	if err != nil {
+		slog.Error("CreatePostRecord", "error", err)
+		return nil
+	}
+
+	records, err := c.postRepo.ListTrackingRecords(0, 100)
+	if err != nil {
+		slog.Error("CreatePostRecord: reload", "error", err)
+		return nil
+	}
+	for _, record := range records {
+		if record.ID == postID {
+			dto := toPostRecordDTO(record)
+			return &dto
+		}
+	}
+	return nil
+}
+
+func (c *AppCommands) ListPostRecords(offset, limit int) []PostRecordDTO {
+	records, err := c.postRepo.ListTrackingRecords(offset, limit)
+	if err != nil {
+		slog.Error("ListPostRecords", "error", err)
+		return nil
+	}
+	result := make([]PostRecordDTO, len(records))
+	for i, record := range records {
+		result[i] = toPostRecordDTO(record)
+	}
+	return result
+}
+
+func (c *AppCommands) GetPostRecordsByAsset(assetID int64) []PostRecordDTO {
+	records, err := c.postRepo.GetTrackingRecordsByAsset(assetID)
+	if err != nil {
+		slog.Error("GetPostRecordsByAsset", "assetID", assetID, "error", err)
+		return nil
+	}
+	result := make([]PostRecordDTO, len(records))
+	for i, record := range records {
+		result[i] = toPostRecordDTO(record)
+	}
+	return result
+}

--- a/internal/commands/post_tracking.go
+++ b/internal/commands/post_tracking.go
@@ -14,24 +14,31 @@ type PostRecordRequest struct {
 	ExternalPostID string  `json:"externalPostId"`
 }
 
-type PostRecordDTO struct {
-	ID                int64   `json:"id"`
-	Title             string  `json:"title"`
-	Status            string  `json:"status"`
-	PublishedAt       string  `json:"publishedAt,omitempty"`
-	CreatedAt         string  `json:"createdAt"`
-	UpdatedAt         string  `json:"updatedAt"`
-	AssetIDs          []int64 `json:"assetIds"`
-	TargetID          int64   `json:"targetId"`
-	TargetName        string  `json:"targetName"`
-	TargetKind        string  `json:"targetKind"`
-	AccountID         int64   `json:"accountId"`
-	AccountDisplay    string  `json:"accountDisplay"`
-	AccountIdentifier string  `json:"accountIdentifier"`
-	ExternalPostID    string  `json:"externalPostId,omitempty"`
+type PostRecordAssetDTO struct {
+	ID       int64  `json:"id"`
+	FileName string `json:"fileName"`
+	FilePath string `json:"filePath"`
 }
 
-func toPostRecordDTO(record db.PostRecordView) PostRecordDTO {
+type PostRecordDTO struct {
+	ID                int64                `json:"id"`
+	Title             string               `json:"title"`
+	Status            string               `json:"status"`
+	PublishedAt       string               `json:"publishedAt,omitempty"`
+	CreatedAt         string               `json:"createdAt"`
+	UpdatedAt         string               `json:"updatedAt"`
+	AssetIDs          []int64              `json:"assetIds"`
+	Assets            []PostRecordAssetDTO `json:"assets"`
+	TargetID          int64                `json:"targetId"`
+	TargetName        string               `json:"targetName"`
+	TargetKind        string               `json:"targetKind"`
+	AccountID         int64                `json:"accountId"`
+	AccountDisplay    string               `json:"accountDisplay"`
+	AccountIdentifier string               `json:"accountIdentifier"`
+	ExternalPostID    string               `json:"externalPostId,omitempty"`
+}
+
+func (c *AppCommands) toPostRecordDTO(record db.PostRecordView) PostRecordDTO {
 	dto := PostRecordDTO{
 		ID:                record.ID,
 		Title:             record.Title,
@@ -39,6 +46,7 @@ func toPostRecordDTO(record db.PostRecordView) PostRecordDTO {
 		CreatedAt:         record.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:         record.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 		AssetIDs:          record.AssetIDs,
+		Assets:            make([]PostRecordAssetDTO, 0, len(record.AssetIDs)),
 		TargetID:          record.TargetID,
 		TargetName:        record.TargetName,
 		TargetKind:        record.TargetKind,
@@ -49,6 +57,21 @@ func toPostRecordDTO(record db.PostRecordView) PostRecordDTO {
 	}
 	if record.PublishedAt != nil {
 		dto.PublishedAt = record.PublishedAt.Format("2006-01-02T15:04:05Z")
+	}
+	for _, assetID := range record.AssetIDs {
+		asset, err := c.assetRepo.GetByID(assetID)
+		if err != nil {
+			slog.Warn("load post record asset", "postID", record.ID, "assetID", assetID, "error", err)
+			continue
+		}
+		if asset == nil {
+			continue
+		}
+		dto.Assets = append(dto.Assets, PostRecordAssetDTO{
+			ID:       asset.ID,
+			FileName: asset.FileName,
+			FilePath: asset.FilePath,
+		})
 	}
 	return dto
 }
@@ -73,7 +96,7 @@ func (c *AppCommands) CreatePostRecord(req PostRecordRequest) *PostRecordDTO {
 	}
 	for _, record := range records {
 		if record.ID == postID {
-			dto := toPostRecordDTO(record)
+			dto := c.toPostRecordDTO(record)
 			return &dto
 		}
 	}
@@ -88,7 +111,7 @@ func (c *AppCommands) ListPostRecords(offset, limit int) []PostRecordDTO {
 	}
 	result := make([]PostRecordDTO, len(records))
 	for i, record := range records {
-		result[i] = toPostRecordDTO(record)
+		result[i] = c.toPostRecordDTO(record)
 	}
 	return result
 }
@@ -101,7 +124,7 @@ func (c *AppCommands) GetPostRecordsByAsset(assetID int64) []PostRecordDTO {
 	}
 	result := make([]PostRecordDTO, len(records))
 	for i, record := range records {
-		result[i] = toPostRecordDTO(record)
+		result[i] = c.toPostRecordDTO(record)
 	}
 	return result
 }

--- a/internal/infrastructure/db/post_tracking_repo.go
+++ b/internal/infrastructure/db/post_tracking_repo.go
@@ -1,0 +1,212 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PostRecordView is a viewer-oriented read model for the actual purpose of
+// Lumine's post feature: remembering which images were registered to which
+// service/account. It intentionally uses the existing post_destinations table
+// instead of treating posts as a text-composer first.
+type PostRecordView struct {
+	ID                int64
+	Title             string
+	Status            string
+	PublishedAt       *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	AssetIDs          []int64
+	TargetID          int64
+	TargetName        string
+	TargetKind        string
+	AccountID         int64
+	AccountDisplay    string
+	AccountIdentifier string
+	ExternalPostID    string
+}
+
+func (r *PostRepo) CreateTrackingRecord(title string, assetIDs []int64, targetID, accountID int64, externalPostID string) (int64, error) {
+	if len(assetIDs) == 0 {
+		return 0, fmt.Errorf("at least one asset is required")
+	}
+	if targetID <= 0 || accountID <= 0 {
+		return 0, fmt.Errorf("post target and account are required")
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	var accountMatches int
+	if err := tx.QueryRow(
+		"SELECT COUNT(*) FROM post_accounts WHERE id = ? AND post_target_id = ? AND is_active = 1",
+		accountID,
+		targetID,
+	).Scan(&accountMatches); err != nil {
+		return 0, fmt.Errorf("validate post account: %w", err)
+	}
+	if accountMatches == 0 {
+		return 0, fmt.Errorf("selected account does not belong to the selected target")
+	}
+
+	title = strings.TrimSpace(title)
+	if title == "" {
+		title = "投稿記録"
+	}
+
+	result, err := tx.Exec(
+		"INSERT INTO posts (title, body, hashtags, status, published_at) VALUES (?, '', '', 'published', CURRENT_TIMESTAMP)",
+		title,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("create post record: %w", err)
+	}
+	postID, err := result.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.Exec(
+		"INSERT INTO post_destinations (post_id, post_target_id, post_account_id, status, published_at, external_post_id) VALUES (?, ?, ?, 'published', CURRENT_TIMESTAMP, ?)",
+		postID,
+		targetID,
+		accountID,
+		strings.TrimSpace(externalPostID),
+	); err != nil {
+		return 0, fmt.Errorf("create post destination: %w", err)
+	}
+
+	seen := make(map[int64]struct{}, len(assetIDs))
+	sortOrder := 0
+	for _, assetID := range assetIDs {
+		if assetID <= 0 {
+			continue
+		}
+		if _, exists := seen[assetID]; exists {
+			continue
+		}
+		seen[assetID] = struct{}{}
+		if _, err := tx.Exec(
+			"INSERT INTO post_assets (post_id, asset_id, sort_order) VALUES (?, ?, ?)",
+			postID,
+			assetID,
+			sortOrder,
+		); err != nil {
+			return 0, fmt.Errorf("attach asset %d: %w", assetID, err)
+		}
+		sortOrder++
+	}
+	if sortOrder == 0 {
+		return 0, fmt.Errorf("no valid assets were supplied")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return postID, nil
+}
+
+func (r *PostRepo) ListTrackingRecords(offset, limit int) ([]PostRecordView, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.db.Query(`
+		SELECT p.id, p.title, p.status, p.published_at, p.created_at, p.updated_at,
+		       t.id, t.name, t.kind,
+		       a.id, a.display_name, a.account_identifier,
+		       COALESCE(d.external_post_id, '')
+		FROM posts p
+		INNER JOIN post_destinations d ON d.post_id = p.id
+		INNER JOIN post_targets t ON t.id = d.post_target_id
+		INNER JOIN post_accounts a ON a.id = d.post_account_id
+		ORDER BY COALESCE(d.published_at, p.published_at, p.updated_at) DESC, p.id DESC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list post records: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]PostRecordView, 0, limit)
+	for rows.Next() {
+		record, err := scanPostRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		assetIDs, err := r.GetAssetsByPostID(record.ID)
+		if err != nil {
+			return nil, err
+		}
+		record.AssetIDs = assetIDs
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func (r *PostRepo) GetTrackingRecordsByAsset(assetID int64) ([]PostRecordView, error) {
+	rows, err := r.db.Query(`
+		SELECT p.id, p.title, p.status, p.published_at, p.created_at, p.updated_at,
+		       t.id, t.name, t.kind,
+		       a.id, a.display_name, a.account_identifier,
+		       COALESCE(d.external_post_id, '')
+		FROM posts p
+		INNER JOIN post_assets pa ON pa.post_id = p.id
+		INNER JOIN post_destinations d ON d.post_id = p.id
+		INNER JOIN post_targets t ON t.id = d.post_target_id
+		INNER JOIN post_accounts a ON a.id = d.post_account_id
+		WHERE pa.asset_id = ?
+		ORDER BY COALESCE(d.published_at, p.published_at, p.updated_at) DESC, p.id DESC`, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("get post records by asset: %w", err)
+	}
+	defer rows.Close()
+
+	var records []PostRecordView
+	for rows.Next() {
+		record, err := scanPostRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		assetIDs, err := r.GetAssetsByPostID(record.ID)
+		if err != nil {
+			return nil, err
+		}
+		record.AssetIDs = assetIDs
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanPostRecord(row rowScanner) (PostRecordView, error) {
+	var record PostRecordView
+	var publishedAt sql.NullTime
+	if err := row.Scan(
+		&record.ID,
+		&record.Title,
+		&record.Status,
+		&publishedAt,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+		&record.TargetID,
+		&record.TargetName,
+		&record.TargetKind,
+		&record.AccountID,
+		&record.AccountDisplay,
+		&record.AccountIdentifier,
+		&record.ExternalPostID,
+	); err != nil {
+		return PostRecordView{}, err
+	}
+	if publishedAt.Valid {
+		record.PublishedAt = &publishedAt.Time
+	}
+	return record, nil
+}

--- a/internal/infrastructure/db/post_tracking_repo_test.go
+++ b/internal/infrastructure/db/post_tracking_repo_test.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kataage/lumine/internal/domain"
+)
+
+func TestPostTrackingRecordRoundTrip(t *testing.T) {
+	dir, err := os.MkdirTemp("", "lumine-post-tracking-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	database, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer database.Close()
+
+	libraryRepo := NewLibraryRepo(database)
+	assetRepo := NewAssetRepo(database)
+	postRepo := NewPostRepo(database)
+	targetRepo := NewPostTargetRepo(database)
+	accountRepo := NewPostAccountRepo(database)
+
+	library, err := libraryRepo.Create("Images", "/tmp/lumine-post-images")
+	if err != nil {
+		t.Fatalf("create library: %v", err)
+	}
+
+	createAsset := func(name string) int64 {
+		t.Helper()
+		id, createErr := assetRepo.Create(&domain.Asset{
+			LibraryID:   library.ID,
+			FolderPath:  "/tmp/lumine-post-images",
+			FileName:    name,
+			FilePath:    "/tmp/lumine-post-images/" + name,
+			Extension:   ".png",
+			FileSize:    1024,
+			ThumbStatus: domain.ThumbStatusNone,
+			StatusLabel: domain.StatusUnsorted,
+		})
+		if createErr != nil {
+			t.Fatalf("create asset %s: %v", name, createErr)
+		}
+		return id
+	}
+
+	assetA := createAsset("a.png")
+	assetB := createAsset("b.png")
+
+	targetID, err := targetRepo.Create("Pixiv", "pixiv")
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	accountID, err := accountRepo.Create(targetID, "main", "kataage")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	postID, err := postRepo.CreateTrackingRecord(
+		"テスト投稿",
+		[]int64{assetA, assetB, assetA},
+		targetID,
+		accountID,
+		"https://example.invalid/post/123",
+	)
+	if err != nil {
+		t.Fatalf("CreateTrackingRecord: %v", err)
+	}
+	if postID == 0 {
+		t.Fatal("expected non-zero post ID")
+	}
+
+	records, err := postRepo.ListTrackingRecords(0, 20)
+	if err != nil {
+		t.Fatalf("ListTrackingRecords: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	record := records[0]
+	if record.ID != postID {
+		t.Errorf("expected post ID %d, got %d", postID, record.ID)
+	}
+	if record.TargetName != "Pixiv" || record.TargetKind != "pixiv" {
+		t.Errorf("unexpected target: %s/%s", record.TargetName, record.TargetKind)
+	}
+	if record.AccountDisplay != "main" || record.AccountIdentifier != "kataage" {
+		t.Errorf("unexpected account: %s/%s", record.AccountDisplay, record.AccountIdentifier)
+	}
+	if record.ExternalPostID != "https://example.invalid/post/123" {
+		t.Errorf("unexpected external ID: %s", record.ExternalPostID)
+	}
+	if len(record.AssetIDs) != 2 || record.AssetIDs[0] != assetA || record.AssetIDs[1] != assetB {
+		t.Errorf("expected deduplicated ordered asset IDs [%d %d], got %v", assetA, assetB, record.AssetIDs)
+	}
+	if record.PublishedAt == nil {
+		t.Error("expected PublishedAt to be set")
+	}
+
+	byAsset, err := postRepo.GetTrackingRecordsByAsset(assetB)
+	if err != nil {
+		t.Fatalf("GetTrackingRecordsByAsset: %v", err)
+	}
+	if len(byAsset) != 1 || byAsset[0].ID != postID {
+		t.Fatalf("expected record %d for asset %d, got %+v", postID, assetB, byAsset)
+	}
+}
+
+func TestPostTrackingRejectsMismatchedAccount(t *testing.T) {
+	dir, err := os.MkdirTemp("", "lumine-post-tracking-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	database, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer database.Close()
+
+	library, _ := NewLibraryRepo(database).Create("Images", "/tmp/lumine-mismatch")
+	assetID, err := NewAssetRepo(database).Create(&domain.Asset{
+		LibraryID:   library.ID,
+		FolderPath:  "/tmp/lumine-mismatch",
+		FileName:    "a.png",
+		FilePath:    "/tmp/lumine-mismatch/a.png",
+		Extension:   ".png",
+		ThumbStatus: domain.ThumbStatusNone,
+		StatusLabel: domain.StatusUnsorted,
+	})
+	if err != nil {
+		t.Fatalf("create asset: %v", err)
+	}
+
+	targetRepo := NewPostTargetRepo(database)
+	accountRepo := NewPostAccountRepo(database)
+	targetA, _ := targetRepo.Create("Pixiv", "pixiv")
+	targetB, _ := targetRepo.Create("X", "twitter")
+	accountB, _ := accountRepo.Create(targetB, "x-main", "@kataage")
+
+	if _, err := NewPostRepo(database).CreateTrackingRecord("bad", []int64{assetID}, targetA, accountB, ""); err == nil {
+		t.Fatal("expected mismatched target/account to be rejected")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -124,9 +124,11 @@ func main() {
 	cmd := commands.New(database, scanSvc)
 
 	err = wails.Run(&options.App{
-		Title:  "Lumine",
-		Width:  1280,
-		Height: 800,
+		Title:     "Lumine",
+		Width:     1280,
+		Height:    800,
+		MinWidth:  800,
+		MinHeight: 600,
 		AssetServer: &assetserver.Options{
 			Assets:     assets,
 			Middleware: localFileMiddleware,


### PR DESCRIPTION
## 概要

画像ビューワーとしての「大きく見る」操作と、Lumine本来の用途である「どの画像をどこへ投稿したかの記録」を中心にUI/UXを再設計します。

## 画像ビューワー
- グリッド上に明示的な「⛶ 拡大」ボタンを追加
- 詳細パネルのプレビュー全体を「大きく表示」操作に変更
- ダブルクリック / Enter でも拡大可能
- `document.body` 直下へPortal表示する全画面モーダルを追加
- ホイール拡大縮小、ドラッグ移動、左右キー移動、Esc、0キー全体表示に対応
- 画面サイズ相当まではメモリ内縮小表示を使い、拡大時だけ元画像を読み込む

## 投稿記録
- 既存DBの `post_destinations` を実際に利用し、画像・投稿先・アカウントを紐付ける投稿記録APIを追加
- 詳細パネルから1画像の投稿記録を直接追加可能
- 複数画像選択時はまとめて1つの投稿記録に登録可能
- 投稿記録モーダル内で投稿先・アカウントをその場で追加可能
- 投稿URL / 外部IDを任意で保存可能
- 左サイドバーを「投稿下書き」中心から「投稿記録一覧」中心へ変更

## レイアウト
- サイドバー、詳細パネル、共通コントロールの寸法をCSS変数へ集約
- ボタン・入力の高さ、文字サイズ、角丸を共通化
- ツールバーを2段構成にし、狭い幅でも横崩れしにくい構造へ変更
- 1080px以下では詳細パネルをオーバーレイ表示し、画像一覧を極端に潰さない
- 画面全体のoverflowとモーダルz-indexを整理

CI / Windows buildを確認しながら仕上げます。