### PR TITLE
feat: ライブラリ自動差分同期・安定描画・画像削除を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ interface AppState {
   thumbnailSize: number;
   filterStatusLabel: string;
   filterRating: number;
+  filterTagIds: number[];
   allAssetIds: number[];
 }
 
@@ -60,6 +61,7 @@ const defaultState: AppState = {
   thumbnailSize: 180,
   filterStatusLabel: "",
   filterRating: 0,
+  filterTagIds: [],
   allAssetIds: [],
 };
 
@@ -131,8 +133,6 @@ export default function App() {
           queryClient.invalidateQueries({ queryKey: ["folderTree", libraryId], refetchType: "active" }),
         ]);
       } catch (error) {
-        // A manual scan can legitimately own the scanner at the same time.
-        // Silent sync is best-effort and will retry on the next interval/focus.
         console.debug("background library sync skipped", error);
       } finally {
         autoSyncRunning.current = false;
@@ -165,7 +165,7 @@ export default function App() {
       const library = await addLibrary(name, path);
       if (!library) throw new Error("ライブラリの登録に失敗しました");
       const libraries = await listLibraries();
-      setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "" }));
+      setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "", filterTagIds: [] }));
       await scanLibrary(library.id);
       const refreshedLibraries = await listLibraries();
       setState((current) => ({ ...current, libraries: refreshedLibraries }));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { SidebarV2, ToolbarV2, WelcomeScreenV2 } from "./components/NavigationV2";
 import { ViewerGridV2 } from "./components/ViewerGridV2";
@@ -7,15 +7,16 @@ import { PostRecordModal } from "./components/PostRecordModal";
 import type { AssetDTO, LibraryDTO } from "./api/client";
 import {
   addLibrary,
-  bulkDeleteAssets,
   bulkUpdateColorLabel,
   bulkUpdateFavorite,
   bulkUpdateRating,
   bulkUpdateStatus,
+  deleteAssetFiles,
   getAppBootstrap,
   listLibraries,
   scanLibrary,
   selectFolder,
+  syncLibrary,
 } from "./api/client";
 import { queryClient } from "./queryClient";
 
@@ -74,12 +75,15 @@ interface BootstrapPayload {
   settings?: Record<string, unknown>;
 }
 
+const AUTO_SYNC_INTERVAL_MS = 15_000;
+
 export default function App() {
   const [state, setState] = useState<AppState>(defaultState);
   const [booting, setBooting] = useState(true);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [addingLibrary, setAddingLibrary] = useState(false);
   const [bulkPostRecordOpen, setBulkPostRecordOpen] = useState(false);
+  const autoSyncRunning = useRef(false);
 
   const loadBootstrap = useCallback(async () => {
     setBooting(true);
@@ -108,6 +112,48 @@ export default function App() {
   }, []);
 
   useEffect(() => { void loadBootstrap(); }, [loadBootstrap]);
+
+  useEffect(() => {
+    const libraryId = state.selectedLibraryId;
+    const library = state.libraries.find((item) => item.id === libraryId);
+    if (!libraryId || !library?.isEnabled) return;
+
+    let disposed = false;
+
+    const run = async () => {
+      if (disposed || document.hidden || autoSyncRunning.current) return;
+      autoSyncRunning.current = true;
+      try {
+        const result = await syncLibrary(libraryId);
+        if (disposed || !result?.changed) return;
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["assets", libraryId], refetchType: "active" }),
+          queryClient.invalidateQueries({ queryKey: ["folderTree", libraryId], refetchType: "active" }),
+        ]);
+      } catch (error) {
+        // A manual scan can legitimately own the scanner at the same time.
+        // Silent sync is best-effort and will retry on the next interval/focus.
+        console.debug("background library sync skipped", error);
+      } finally {
+        autoSyncRunning.current = false;
+      }
+    };
+
+    const initialTimer = window.setTimeout(() => void run(), 1200);
+    const interval = window.setInterval(() => void run(), AUTO_SYNC_INTERVAL_MS);
+    const onFocus = () => void run();
+    const onVisibility = () => { if (!document.hidden) void run(); };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(initialTimer);
+      window.clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [state.libraries, state.selectedLibraryId]);
 
   const handleSelectFolder = useCallback(async () => {
     if (addingLibrary) return;
@@ -161,8 +207,18 @@ export default function App() {
   const handleCloseDetail = useCallback(() => setState((current) => ({ ...current, detailOpen: false, detailAsset: null })), []);
   const handleAssetsLoaded = useCallback((ids: number[]) => {
     setState((current) => {
-      if (current.allAssetIds.length === ids.length && current.allAssetIds.every((id, index) => id === ids[index])) return current;
-      return { ...current, allAssetIds: ids };
+      const sameIds = current.allAssetIds.length === ids.length && current.allAssetIds.every((id, index) => id === ids[index]);
+      const available = new Set(ids);
+      const selectedAssets = new Set(Array.from(current.selectedAssets).filter((id) => available.has(id)));
+      const detailStillExists = !current.detailAsset || available.has(current.detailAsset.id);
+      if (sameIds && selectedAssets.size === current.selectedAssets.size && detailStillExists) return current;
+      return {
+        ...current,
+        allAssetIds: ids,
+        selectedAssets,
+        detailOpen: detailStillExists ? current.detailOpen : false,
+        detailAsset: detailStillExists ? current.detailAsset : null,
+      };
     });
   }, []);
 
@@ -192,19 +248,33 @@ export default function App() {
     await queryClient.invalidateQueries({ queryKey: ["assets"] });
   }, [state.selectedAssets]);
 
-  const handleBulkDelete = useCallback(async () => {
+  const handleDeleteFiles = useCallback(async () => {
     const ids = Array.from(state.selectedAssets);
     if (!ids.length) return;
-    if (!confirm(`選択した${ids.length}件をLumineの一覧から削除します。\n元の画像ファイルは削除されません。\n\n続行しますか？`)) return;
+    const label = ids.length === 1 ? "選択した画像" : `選択した${ids.length}件の画像`;
+    if (!confirm(`${label}の元画像ファイルを削除します。\n\nこの操作は元に戻せません。Lumineの登録情報も同時に削除されます。\n\n本当に削除しますか？`)) return;
+
     try {
-      await bulkDeleteAssets(ids);
-      setState((current) => ({ ...current, selectedAssets: new Set<number>(), detailOpen: false, detailAsset: null }));
-      await queryClient.invalidateQueries({ queryKey: ["assets"] });
+      const result = await deleteAssetFiles(ids);
+      const deleted = new Set(result.deletedIds);
+      setState((current) => ({
+        ...current,
+        selectedAssets: new Set(Array.from(current.selectedAssets).filter((id) => !deleted.has(id))),
+        detailOpen: current.detailAsset && deleted.has(current.detailAsset.id) ? false : current.detailOpen,
+        detailAsset: current.detailAsset && deleted.has(current.detailAsset.id) ? null : current.detailAsset,
+        lastSelectedIndex: null,
+      }));
+      await queryClient.invalidateQueries({ queryKey: ["assets", state.selectedLibraryId], refetchType: "active" });
+
+      if (result.failedCount > 0) {
+        const details = (result.errors ?? []).slice(0, 5).join("\n");
+        alert(`${result.deletedCount}件を削除しましたが、${result.failedCount}件は削除できませんでした。${details ? `\n\n${details}` : ""}`);
+      }
     } catch (error) {
-      console.error("bulk delete failed:", error);
-      alert("一覧からの削除に失敗しました。");
+      console.error("image file delete failed:", error);
+      alert("画像ファイルの削除に失敗しました。\n" + (error instanceof Error ? error.message : String(error)));
     }
-  }, [state.selectedAssets]);
+  }, [state.selectedAssets, state.selectedLibraryId]);
 
   if (booting) {
     return <div className="h-screen bg-background text-foreground flex items-center justify-center"><div className="flex flex-col items-center gap-3 text-sm text-muted-foreground"><div className="w-6 h-6 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin" /><span>Lumineを起動しています…</span></div></div>;
@@ -229,7 +299,7 @@ export default function App() {
               <div className="flex-1 min-w-0 flex"><ViewerGridV2 onSelectAsset={handleSelectAsset} onAssetsLoaded={handleAssetsLoaded} /></div>
               {state.detailOpen && state.detailAsset && <AssetDetailPanel asset={state.detailAsset} onClose={handleCloseDetail} />}
             </div>
-            {state.selectedAssets.size > 1 && (
+            {state.selectedAssets.size > 0 && (
               <BulkActionsBar
                 count={state.selectedAssets.size}
                 onRate={handleBulkRate}
@@ -237,7 +307,7 @@ export default function App() {
                 onFavorite={handleBulkFavorite}
                 onColorLabel={handleBulkColorLabel}
                 onPostRecord={() => setBulkPostRecordOpen(true)}
-                onDelete={handleBulkDelete}
+                onDelete={handleDeleteFiles}
                 onClear={() => setState((current) => ({ ...current, selectedAssets: new Set(), lastSelectedIndex: null }))}
               />
             )}
@@ -277,7 +347,7 @@ export function BulkActionsBar({ count, onRate, onStatus, onFavorite, onColorLab
       <div className="h-5 w-px bg-border" />
       <button onClick={() => onFavorite(true)} className="ui-secondary-button">★ お気に入り</button>
       <button onClick={onPostRecord} className="ui-primary-button">＋ 投稿記録</button>
-      <button onClick={onDelete} className="h-8 px-3 rounded-lg bg-destructive text-destructive-foreground text-[11px] font-medium whitespace-nowrap">一覧から削除</button>
+      <button onClick={onDelete} className="h-8 px-3 rounded-lg bg-destructive text-destructive-foreground text-[11px] font-medium whitespace-nowrap">画像ファイルを削除</button>
       <div className="flex-1 min-w-3" />
       <button onClick={onClear} className="ui-secondary-button">選択解除</button>
     </div>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -59,6 +59,25 @@ export interface ScanProgress {
   isDone: boolean;
 }
 
+export interface LibrarySyncResult {
+  libraryId: number;
+  scannedCount: number;
+  addedCount: number;
+  updatedCount: number;
+  removedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  changed: boolean;
+}
+
+export interface DeleteAssetFilesResult {
+  deletedCount: number;
+  failedCount: number;
+  deletedIds: number[];
+  failedIds: number[];
+  errors?: string[];
+}
+
 export const selectFolder = Go.SelectFolder;
 export const listLibraries = Go.ListLibraries;
 export const addLibrary = Go.AddLibrary;
@@ -79,6 +98,8 @@ function appCommands() {
         AppCommands?: {
           GetViewerAssetDetail?: (id: number) => Promise<AssetDTO | null>;
           ScanLibraryViewer?: (libraryId: number) => Promise<void>;
+          SyncLibraryViewer?: (libraryId: number) => Promise<LibrarySyncResult | null>;
+          DeleteAssetFiles?: (ids: number[]) => Promise<DeleteAssetFilesResult | null>;
           CreatePostRecord?: (request: PostRecordRequest) => Promise<PostRecordDTO | null>;
           ListPostRecords?: (offset: number, limit: number) => Promise<PostRecordDTO[]>;
           GetPostRecordsByAsset?: (assetId: number) => Promise<PostRecordDTO[]>;
@@ -96,13 +117,30 @@ export async function getAssetDetail(assetId: number): Promise<AssetDTO | null> 
 
 export async function scanLibrary(libraryId: number): Promise<void> {
   const method = appCommands()?.ScanLibraryViewer;
-  if (method) await method(libraryId);
-  else await Go.ScanLibrary(libraryId);
+  if (method) {
+    await method(libraryId);
+    return;
+  }
+  await Go.ScanLibrary(libraryId);
+}
 
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: ["assets", libraryId] }),
-    queryClient.invalidateQueries({ queryKey: ["folderTree", libraryId] }),
-  ]);
+export async function syncLibrary(libraryId: number): Promise<LibrarySyncResult | null> {
+  const method = appCommands()?.SyncLibraryViewer;
+  if (!method) return null;
+  return method(libraryId);
+}
+
+export async function deleteAssetFiles(ids: number[]): Promise<DeleteAssetFilesResult> {
+  const method = appCommands()?.DeleteAssetFiles;
+  if (!method) throw new Error("画像削除APIが利用できません。最新版のLumineを起動してください。");
+  const result = await method(ids);
+  if (!result) throw new Error("画像削除の結果を取得できませんでした。");
+  return {
+    ...result,
+    deletedIds: result.deletedIds ?? [],
+    failedIds: result.failedIds ?? [],
+    errors: result.errors ?? [],
+  };
 }
 
 export async function createPostRecord(request: PostRecordRequest): Promise<PostRecordDTO | null> {

--- a/frontend/src/components/AssetDetailPanel.tsx
+++ b/frontend/src/components/AssetDetailPanel.tsx
@@ -5,7 +5,6 @@ import {
   getAssetDetail,
   getPostRecordsByAsset,
   listTags,
-  setAssetTags,
   toggleAssetFavorite,
   updateAssetColorLabel,
   updateAssetNote,
@@ -16,6 +15,7 @@ import { formatFileSize } from "../utils/format";
 import { ImageViewerModal } from "./ImageViewerModal";
 import { MemoryImage } from "./MemoryImage";
 import { PostRecordModal } from "./PostRecordModal";
+import { TagPicker } from "./TagPicker";
 
 interface AssetDetailPanelProps {
   asset: AssetDTO;
@@ -314,25 +314,13 @@ export function AssetDetailPanel({ asset: listAsset, onClose }: AssetDetailPanel
           </Section>
 
           <Section title="タグ">
-            <div className="flex flex-wrap gap-1.5">
-              {tags.length > 0 ? tags.map((tag) => {
-                const active = asset.tags?.some((item) => item.id === tag.id) ?? false;
-                return (
-                  <button
-                    key={tag.id}
-                    onClick={async () => {
-                      const current = asset.tags?.map((item) => item.id) ?? [];
-                      const next = active ? current.filter((id) => id !== tag.id) : [...current, tag.id];
-                      await setAssetTags(asset.id, next);
-                      await refreshAll();
-                    }}
-                    className={`h-7 px-2.5 rounded-full border text-[11px] ${active ? "bg-primary/15 border-primary/40 text-foreground" : "bg-muted border-border text-muted-foreground"}`}
-                  >
-                    <span className="inline-block w-2 h-2 rounded-full mr-1" style={{ backgroundColor: tag.color }} />{tag.name}
-                  </button>
-                );
-              }) : <p className="text-[11px] text-muted-foreground">タグはまだありません。</p>}
-            </div>
+            <TagPicker
+              assetId={asset.id}
+              tags={tags}
+              assignedTags={asset.tags ?? []}
+              onAssignedTagsChange={(nextTags) => setAsset((current) => ({ ...current, tags: nextTags } as AssetDTO))}
+              onChanged={refreshAll}
+            />
           </Section>
 
           <Section title="メモ">

--- a/frontend/src/components/MemoryImage.tsx
+++ b/frontend/src/components/MemoryImage.tsx
@@ -28,6 +28,7 @@ export function MemoryImage({
   className = "",
 }: MemoryImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const hasRenderedRef = useRef(false);
   const [loading, setLoading] = useState(true);
   const [fallback, setFallback] = useState(false);
   const [fallbackError, setFallbackError] = useState(false);
@@ -39,9 +40,7 @@ export function MemoryImage({
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setFallback(false);
-    setFallbackError(false);
+    if (!hasRenderedRef.current) setLoading(true);
 
     const canvas = canvasRef.current;
     if (!filePath) {
@@ -54,7 +53,7 @@ export function MemoryImage({
 
     if (!canvas || typeof createImageBitmap !== "function") {
       setFallback(true);
-      setLoading(false);
+      setFallbackError(false);
       return () => {
         cancelled = true;
       };
@@ -62,9 +61,10 @@ export function MemoryImage({
 
     const targetWidth = Math.max(1, Math.round(width * pixelRatio));
     const targetHeight = Math.max(1, Math.round(height * pixelRatio));
-    canvas.width = targetWidth;
-    canvas.height = targetHeight;
 
+    // Do not resize/clear the canvas before the replacement bitmap is ready.
+    // Keeping the previous pixels stretched by CSS avoids the black flash on a
+    // library refresh or when switching thumbnail size from medium to large.
     loadMemoryBitmap({
       filePath,
       modifiedAtFs,
@@ -79,17 +79,25 @@ export function MemoryImage({
         if (cancelled) return;
         const ctx = canvas.getContext("2d", { alpha: false });
         if (!ctx) throw new Error("2D canvas unavailable");
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
         ctx.clearRect(0, 0, targetWidth, targetHeight);
         const x = Math.floor((targetWidth - bitmap.width) / 2);
         const y = Math.floor((targetHeight - bitmap.height) / 2);
         ctx.drawImage(bitmap, x, y);
+        hasRenderedRef.current = true;
+        setFallback(false);
+        setFallbackError(false);
         setLoading(false);
       })
       .catch((error) => {
         if (cancelled) return;
         console.debug("Memory image decode fallback", filePath, error);
+        // Keep the existing canvas under the fallback image until the browser
+        // has decoded that image too. This avoids replacing a valid preview
+        // with an empty frame just because the high-quality decode failed.
         setFallback(true);
-        setLoading(false);
+        setFallbackError(false);
       });
 
     return () => {
@@ -104,25 +112,31 @@ export function MemoryImage({
       role="img"
       aria-label={alt || undefined}
     >
-      {loading && <div className="absolute inset-0 bg-muted animate-pulse" />}
+      {loading && !hasRenderedRef.current && <div className="absolute inset-0 bg-muted animate-pulse" />}
       <canvas
         ref={canvasRef}
-        className={`w-full h-full ${fallback ? "hidden" : "block"}`}
+        className="block w-full h-full"
         style={{ width, height }}
       />
       {fallback && !fallbackError && (
         <img
           src={getLocalImageUrl(filePath)}
           alt={alt}
-          className={`w-full h-full ${fit === "cover" ? "object-cover" : "object-contain"}`}
+          className={`absolute inset-0 w-full h-full ${fit === "cover" ? "object-cover" : "object-contain"}`}
           decoding="async"
           draggable={false}
-          onLoad={() => setLoading(false)}
-          onError={() => setFallbackError(true)}
+          onLoad={() => {
+            hasRenderedRef.current = true;
+            setLoading(false);
+          }}
+          onError={() => {
+            setFallbackError(true);
+            setLoading(false);
+          }}
         />
       )}
       {fallbackError && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-muted-foreground/50 text-[10px]">
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-muted-foreground/50 text-[10px] bg-muted/80">
           <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
           </svg>

--- a/frontend/src/components/MemoryImage.tsx
+++ b/frontend/src/components/MemoryImage.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getLocalImageUrl } from "../api/client";
-import { loadMemoryBitmap, type ImageDecodePriority, type ImageFit } from "../utils/imagePipeline";
+import {
+  computeCoverCrop,
+  getCachedMemoryBitmap,
+  loadMemoryBitmap,
+  type ImageDecodePriority,
+  type ImageFit,
+} from "../utils/imagePipeline";
 
 interface MemoryImageProps {
   filePath: string;
@@ -13,6 +19,45 @@ interface MemoryImageProps {
   priority?: ImageDecodePriority;
   alt?: string;
   className?: string;
+}
+
+function paintCachedPlaceholder(
+  canvas: HTMLCanvasElement,
+  bitmap: ImageBitmap,
+  targetWidth: number,
+  targetHeight: number,
+  fit: ImageFit
+): boolean {
+  const ctx = canvas.getContext("2d", { alpha: false });
+  if (!ctx) return false;
+
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+  ctx.clearRect(0, 0, targetWidth, targetHeight);
+
+  if (fit === "cover") {
+    const crop = computeCoverCrop(bitmap.width, bitmap.height, targetWidth, targetHeight);
+    ctx.drawImage(
+      bitmap,
+      crop.x,
+      crop.y,
+      crop.width,
+      crop.height,
+      0,
+      0,
+      targetWidth,
+      targetHeight
+    );
+    return true;
+  }
+
+  const scale = Math.min(targetWidth / Math.max(1, bitmap.width), targetHeight / Math.max(1, bitmap.height));
+  const drawWidth = Math.max(1, Math.round(bitmap.width * scale));
+  const drawHeight = Math.max(1, Math.round(bitmap.height * scale));
+  const x = Math.floor((targetWidth - drawWidth) / 2);
+  const y = Math.floor((targetHeight - drawHeight) / 2);
+  ctx.drawImage(bitmap, x, y, drawWidth, drawHeight);
+  return true;
 }
 
 export function MemoryImage({
@@ -61,11 +106,7 @@ export function MemoryImage({
 
     const targetWidth = Math.max(1, Math.round(width * pixelRatio));
     const targetHeight = Math.max(1, Math.round(height * pixelRatio));
-
-    // Do not resize/clear the canvas before the replacement bitmap is ready.
-    // Keeping the previous pixels stretched by CSS avoids the black flash on a
-    // library refresh or when switching thumbnail size from medium to large.
-    loadMemoryBitmap({
+    const request = {
       filePath,
       modifiedAtFs,
       sourceWidth,
@@ -74,7 +115,24 @@ export function MemoryImage({
       targetHeight,
       fit,
       priority,
-    })
+    } as const;
+
+    // A thumbnail-size change can regroup virtualized rows and remount cards.
+    // In that case there is no old canvas to preserve, so paint the closest
+    // already-decoded bitmap from the memory LRU synchronously. The sharper
+    // requested bitmap replaces it as soon as decoding finishes.
+    if (!hasRenderedRef.current) {
+      const cachedPlaceholder = getCachedMemoryBitmap(request);
+      if (cachedPlaceholder && paintCachedPlaceholder(canvas, cachedPlaceholder, targetWidth, targetHeight, fit)) {
+        hasRenderedRef.current = true;
+        setLoading(false);
+      }
+    }
+
+    // Do not resize/clear an already-rendered canvas before the replacement
+    // bitmap is ready. CSS can stretch the existing pixels temporarily without
+    // ever presenting an empty black frame.
+    loadMemoryBitmap(request)
       .then((bitmap) => {
         if (cancelled) return;
         const ctx = canvas.getContext("2d", { alpha: false });

--- a/frontend/src/components/NavigationV2.tsx
+++ b/frontend/src/components/NavigationV2.tsx
@@ -143,7 +143,7 @@ function LibrariesPanel({ scanProgress }: { scanProgress: Record<number, ScanPro
     const library = await addLibrary(name, path);
     if (!library) return;
     const libraries = await listLibraries();
-    setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "" }));
+    setState((current) => ({ ...current, libraries, selectedLibraryId: library.id, selectedFolderPath: "", searchQuery: "", filterTagIds: [] }));
     await scanLibrary(library.id);
   };
 
@@ -156,7 +156,7 @@ function LibrariesPanel({ scanProgress }: { scanProgress: Record<number, ScanPro
           const progress = scanProgress[library.id];
           return (
             <div key={library.id} className={`rounded-xl border p-2.5 ${selected ? "border-primary/40 bg-primary/10" : "border-border bg-muted/15"}`}>
-              <button className="w-full text-left min-w-0" onClick={() => setState((current) => ({ ...current, selectedLibraryId: library.id, selectedFolderPath: "", selectedAssets: new Set(), detailOpen: false, detailAsset: null }))}>
+              <button className="w-full text-left min-w-0" onClick={() => setState((current) => ({ ...current, selectedLibraryId: library.id, selectedFolderPath: "", selectedAssets: new Set(), detailOpen: false, detailAsset: null, filterTagIds: [] }))}>
                 <p className="text-xs font-medium truncate">{library.name}</p>
                 <p className="mt-0.5 text-[10px] text-muted-foreground truncate">{library.rootPath}</p>
               </button>
@@ -171,7 +171,7 @@ function LibrariesPanel({ scanProgress }: { scanProgress: Record<number, ScanPro
                   if (!confirm(`「${library.name}」の登録を解除しますか？\n元画像は削除されません。`)) return;
                   await removeLibrary(library.id);
                   const libraries = await listLibraries();
-                  setState((current) => ({ ...current, libraries, selectedLibraryId: current.selectedLibraryId === library.id ? (libraries[0]?.id ?? null) : current.selectedLibraryId, selectedFolderPath: "", detailOpen: false, detailAsset: null }));
+                  setState((current) => ({ ...current, libraries, selectedLibraryId: current.selectedLibraryId === library.id ? (libraries[0]?.id ?? null) : current.selectedLibraryId, selectedFolderPath: "", detailOpen: false, detailAsset: null, filterTagIds: [] }));
                 }}>登録解除</button>
               </div>
             </div>
@@ -218,6 +218,7 @@ function FoldersPanel() {
 
 function TagsPanel() {
   const queryClient = useQueryClient();
+  const { state, setState } = useApp();
   const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
   const [name, setName] = useState("");
   const [color, setColor] = useState("#6366f1");
@@ -225,14 +226,32 @@ function TagsPanel() {
   const searchKey = search.trim().toLocaleLowerCase("ja-JP");
   const filteredTags = useMemo(() => {
     const next = tags.filter((tag) => !searchKey || tag.name.toLocaleLowerCase("ja-JP").includes(searchKey));
-    next.sort((a, b) => tagNameCollator.compare(a.name, b.name));
+    next.sort((a, b) => {
+      const aActive = state.filterTagIds.includes(a.id);
+      const bActive = state.filterTagIds.includes(b.id);
+      if (aActive !== bActive) return aActive ? -1 : 1;
+      return tagNameCollator.compare(a.name, b.name);
+    });
     return next;
-  }, [searchKey, tags]);
+  }, [searchKey, state.filterTagIds, tags]);
   const visibleTags = filteredTags.slice(0, TAG_MANAGER_VISIBLE_LIMIT);
+
+  const toggleFilterTag = (tagId: number) => {
+    setState((current) => ({
+      ...current,
+      filterTagIds: current.filterTagIds.includes(tagId)
+        ? current.filterTagIds.filter((id) => id !== tagId)
+        : [...current.filterTagIds, tagId],
+      selectedAssets: new Set(),
+      lastSelectedIndex: null,
+      detailOpen: false,
+      detailAsset: null,
+    }));
+  };
 
   return (
     <div className="pb-3">
-      <PanelTitle title="タグ" description={`画像の分類用タグを管理します。現在 ${tags.length}件`} />
+      <PanelTitle title="タグ" description={`クリックで画像を絞り込み。現在 ${tags.length}件`} />
       <div className="px-3 space-y-3">
         <div className="rounded-xl border border-border bg-muted/15 p-2.5 space-y-2">
           <p className="text-[10px] font-medium text-muted-foreground">新しいタグ</p>
@@ -247,26 +266,41 @@ function TagsPanel() {
           <label className="ui-label" htmlFor="tag-manager-search">タグを検索</label>
           <input id="tag-manager-search" className="ui-input w-full" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="タグ名で絞り込み…" autoComplete="off" />
           <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-            <span>{searchKey ? `${filteredTags.length}件ヒット` : `${tags.length}件`}</span>
+            <span>{searchKey ? `${filteredTags.length}件ヒット` : `${tags.length}件`}{state.filterTagIds.length > 0 ? ` · ${state.filterTagIds.length}件で絞り込み中` : ""}</span>
             {filteredTags.length > TAG_MANAGER_VISIBLE_LIMIT && <span>上位{TAG_MANAGER_VISIBLE_LIMIT}件を表示</span>}
           </div>
         </div>
 
         <div className="max-h-[52vh] overflow-y-auto rounded-lg border border-border p-1 space-y-0.5">
-          {visibleTags.map((tag) => (
-            <div key={tag.id} className="min-h-9 px-2 rounded-lg flex items-center gap-2 hover:bg-accent/50">
-              <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color }} />
-              <span className="text-xs min-w-0 flex-1 truncate" title={tag.name}>{tag.name}</span>
-              <button
-                className="text-[11px] text-muted-foreground hover:text-destructive"
-                onClick={async () => {
-                  if (!confirm(`タグ「${tag.name}」を削除しますか？\n画像へのタグ付けも解除されます。`)) return;
-                  await deleteTag(tag.id);
-                  await queryClient.invalidateQueries({ queryKey: ["tags"] });
-                }}
-              >削除</button>
-            </div>
-          ))}
+          {visibleTags.map((tag) => {
+            const active = state.filterTagIds.includes(tag.id);
+            return (
+              <div key={tag.id} className={`min-h-9 rounded-lg flex items-center gap-1 ${active ? "bg-primary/12 ring-1 ring-primary/25" : "hover:bg-accent/50"}`}>
+                <button
+                  type="button"
+                  className="min-w-0 flex-1 h-9 px-2 flex items-center gap-2 text-left"
+                  onClick={() => toggleFilterTag(tag.id)}
+                  title={active ? `「${tag.name}」の絞り込みを解除` : `「${tag.name}」で画像を絞り込み`}
+                >
+                  <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color }} />
+                  <span className="text-xs min-w-0 flex-1 truncate">{tag.name}</span>
+                  <span className={`text-[10px] ${active ? "text-primary font-medium" : "text-muted-foreground"}`}>{active ? "✓ 絞込中" : "絞込"}</span>
+                </button>
+                <button
+                  className="h-9 px-2 text-[11px] text-muted-foreground hover:text-destructive flex-shrink-0"
+                  onClick={async () => {
+                    if (!confirm(`タグ「${tag.name}」を削除しますか？\n画像へのタグ付けも解除されます。`)) return;
+                    await deleteTag(tag.id);
+                    setState((current) => ({ ...current, filterTagIds: current.filterTagIds.filter((id) => id !== tag.id) }));
+                    await Promise.all([
+                      queryClient.invalidateQueries({ queryKey: ["tags"] }),
+                      queryClient.invalidateQueries({ queryKey: ["assets"] }),
+                    ]);
+                  }}
+                >削除</button>
+              </div>
+            );
+          })}
           {visibleTags.length === 0 && <p className="py-5 text-center text-[11px] text-muted-foreground">該当するタグはありません</p>}
         </div>
         {filteredTags.length > TAG_MANAGER_VISIBLE_LIMIT && <p className="text-[10px] leading-relaxed text-muted-foreground">タグ数が多いため先頭{TAG_MANAGER_VISIBLE_LIMIT}件だけ表示しています。検索欄へ数文字入力すると残りもすぐ探せます。</p>}
@@ -385,6 +419,10 @@ export function ToolbarV2() {
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const library = state.libraries.find((item) => item.id === state.selectedLibraryId);
   const folderName = state.selectedFolderPath.split(/[\\/]/).pop() || "";
+  const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
+  const selectedTagNames = state.filterTagIds
+    .map((id) => tags.find((tag) => tag.id === id)?.name)
+    .filter((name): name is string => Boolean(name));
   useEffect(() => setSearch(state.searchQuery), [state.searchQuery]);
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
@@ -394,7 +432,7 @@ export function ToolbarV2() {
     timer.current = setTimeout(() => setState((current) => ({ ...current, searchQuery: value })), 250);
   };
 
-  const hasFilters = !!(state.selectedFolderPath || state.searchQuery || state.filterStatusLabel || state.filterRating);
+  const hasFilters = !!(state.selectedFolderPath || state.searchQuery || state.filterStatusLabel || state.filterRating || state.filterTagIds.length);
   return (
     <header className="toolbar-v2 border-b border-border bg-card/80 flex-shrink-0">
       <div className="toolbar-primary-row">
@@ -422,7 +460,12 @@ export function ToolbarV2() {
           {state.searchQuery && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, searchQuery: "" }))}>検索: {state.searchQuery} ×</button>}
           {state.filterStatusLabel && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, filterStatusLabel: "" }))}>状態 ×</button>}
           {state.filterRating > 0 && <button className="filter-chip" onClick={() => setState((current) => ({ ...current, filterRating: 0 }))}>★{state.filterRating} ×</button>}
-          <button className="text-[10px] text-muted-foreground hover:text-foreground" onClick={() => setState((current) => ({ ...current, selectedFolderPath: "", searchQuery: "", filterStatusLabel: "", filterRating: 0 }))}>すべて解除</button>
+          {state.filterTagIds.length > 0 && (
+            <button className="filter-chip" onClick={() => setState((current) => ({ ...current, filterTagIds: [] }))} title={selectedTagNames.join(", ")}>
+              タグ: {state.filterTagIds.length === 1 && selectedTagNames[0] ? selectedTagNames[0] : `${state.filterTagIds.length}件`} ×
+            </button>
+          )}
+          <button className="text-[10px] text-muted-foreground hover:text-foreground" onClick={() => setState((current) => ({ ...current, selectedFolderPath: "", searchQuery: "", filterStatusLabel: "", filterRating: 0, filterTagIds: [] }))}>すべて解除</button>
         </div>
       )}
     </header>

--- a/frontend/src/components/NavigationV2.tsx
+++ b/frontend/src/components/NavigationV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApp } from "../App";
 import {
@@ -37,6 +37,9 @@ const NAV_ITEMS = [
   ["posts", "投稿記録", "投稿先を確認"],
   ["settings", "設定", "読み込み・操作"],
 ] as const;
+
+const TAG_MANAGER_VISIBLE_LIMIT = 200;
+const tagNameCollator = new Intl.Collator("ja", { sensitivity: "base", numeric: true });
 
 export function WelcomeScreenV2({ onSelectFolder, busy = false }: { onSelectFolder: () => void; busy?: boolean }) {
   return (
@@ -218,18 +221,55 @@ function TagsPanel() {
   const { data: tags = [] } = useQuery({ queryKey: ["tags"], queryFn: listTags, staleTime: Infinity });
   const [name, setName] = useState("");
   const [color, setColor] = useState("#6366f1");
+  const [search, setSearch] = useState("");
+  const searchKey = search.trim().toLocaleLowerCase("ja-JP");
+  const filteredTags = useMemo(() => {
+    const next = tags.filter((tag) => !searchKey || tag.name.toLocaleLowerCase("ja-JP").includes(searchKey));
+    next.sort((a, b) => tagNameCollator.compare(a.name, b.name));
+    return next;
+  }, [searchKey, tags]);
+  const visibleTags = filteredTags.slice(0, TAG_MANAGER_VISIBLE_LIMIT);
+
   return (
     <div className="pb-3">
-      <PanelTitle title="タグ" description="画像の分類用タグを管理します。" />
+      <PanelTitle title="タグ" description={`画像の分類用タグを管理します。現在 ${tags.length}件`} />
       <div className="px-3 space-y-3">
-        <div className="grid grid-cols-[minmax(0,1fr)_36px_auto] gap-2">
-          <input className="ui-input min-w-0" value={name} onChange={(event) => setName(event.target.value)} placeholder="タグ名" />
-          <input type="color" className="w-9 h-9 rounded-lg border border-border bg-transparent" value={color} onChange={(event) => setColor(event.target.value)} />
-          <button className="ui-primary-button" onClick={async () => { if (!name.trim()) return; await createTag(name.trim(), color); setName(""); await queryClient.invalidateQueries({ queryKey: ["tags"] }); }}>追加</button>
+        <div className="rounded-xl border border-border bg-muted/15 p-2.5 space-y-2">
+          <p className="text-[10px] font-medium text-muted-foreground">新しいタグ</p>
+          <div className="grid grid-cols-[minmax(0,1fr)_36px_auto] gap-2">
+            <input className="ui-input min-w-0" value={name} onChange={(event) => setName(event.target.value)} placeholder="タグ名" />
+            <input type="color" className="w-9 h-9 rounded-lg border border-border bg-transparent" value={color} onChange={(event) => setColor(event.target.value)} />
+            <button className="ui-primary-button" onClick={async () => { if (!name.trim()) return; await createTag(name.trim(), color); setName(""); await queryClient.invalidateQueries({ queryKey: ["tags"] }); }}>追加</button>
+          </div>
         </div>
-        <div className="space-y-1">
-          {tags.map((tag) => <div key={tag.id} className="min-h-9 px-2.5 rounded-lg flex items-center gap-2 hover:bg-accent/50"><span className="w-3 h-3 rounded-full" style={{ backgroundColor: tag.color }} /><span className="text-xs min-w-0 flex-1 truncate">{tag.name}</span><button className="text-[11px] text-muted-foreground hover:text-destructive" onClick={async () => { await deleteTag(tag.id); await queryClient.invalidateQueries({ queryKey: ["tags"] }); }}>削除</button></div>)}
+
+        <div className="space-y-1.5">
+          <label className="ui-label" htmlFor="tag-manager-search">タグを検索</label>
+          <input id="tag-manager-search" className="ui-input w-full" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="タグ名で絞り込み…" autoComplete="off" />
+          <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+            <span>{searchKey ? `${filteredTags.length}件ヒット` : `${tags.length}件`}</span>
+            {filteredTags.length > TAG_MANAGER_VISIBLE_LIMIT && <span>上位{TAG_MANAGER_VISIBLE_LIMIT}件を表示</span>}
+          </div>
         </div>
+
+        <div className="max-h-[52vh] overflow-y-auto rounded-lg border border-border p-1 space-y-0.5">
+          {visibleTags.map((tag) => (
+            <div key={tag.id} className="min-h-9 px-2 rounded-lg flex items-center gap-2 hover:bg-accent/50">
+              <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color }} />
+              <span className="text-xs min-w-0 flex-1 truncate" title={tag.name}>{tag.name}</span>
+              <button
+                className="text-[11px] text-muted-foreground hover:text-destructive"
+                onClick={async () => {
+                  if (!confirm(`タグ「${tag.name}」を削除しますか？\n画像へのタグ付けも解除されます。`)) return;
+                  await deleteTag(tag.id);
+                  await queryClient.invalidateQueries({ queryKey: ["tags"] });
+                }}
+              >削除</button>
+            </div>
+          ))}
+          {visibleTags.length === 0 && <p className="py-5 text-center text-[11px] text-muted-foreground">該当するタグはありません</p>}
+        </div>
+        {filteredTags.length > TAG_MANAGER_VISIBLE_LIMIT && <p className="text-[10px] leading-relaxed text-muted-foreground">タグ数が多いため先頭{TAG_MANAGER_VISIBLE_LIMIT}件だけ表示しています。検索欄へ数文字入力すると残りもすぐ探せます。</p>}
       </div>
     </div>
   );

--- a/frontend/src/components/PostRecordModal.tsx
+++ b/frontend/src/components/PostRecordModal.tsx
@@ -122,11 +122,21 @@ export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved 
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-[110] bg-black/65 backdrop-blur-sm flex items-center justify-center p-4" onMouseDown={(event) => {
-      if (event.currentTarget === event.target && !busy) onClose();
-    }}>
-      <div className="w-full max-w-xl max-h-[calc(100dvh-32px)] overflow-hidden rounded-2xl border border-border bg-card shadow-2xl" role="dialog" aria-modal="true" aria-label="投稿記録を追加">
-        <div className="h-14 px-4 border-b border-border flex items-center justify-between gap-3">
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center p-4"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.82)", backdropFilter: "blur(2px)" }}
+      onMouseDown={(event) => {
+        if (event.currentTarget === event.target && !busy) onClose();
+      }}
+    >
+      <div
+        className="w-full max-w-xl max-h-[calc(100dvh-32px)] overflow-hidden rounded-2xl border border-border shadow-2xl isolate"
+        style={{ backgroundColor: "hsl(var(--card))", color: "hsl(var(--card-foreground))", boxShadow: "0 24px 80px rgba(0, 0, 0, 0.7)" }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="投稿記録を追加"
+      >
+        <div className="h-14 px-4 border-b border-border flex items-center justify-between gap-3" style={{ backgroundColor: "hsl(var(--card))" }}>
           <div className="min-w-0">
             <h2 className="text-sm font-semibold">投稿記録を追加</h2>
             <p className="text-[11px] text-muted-foreground truncate">選択した{assetIds.length}件の画像を、どこへ投稿したか記録します。</p>
@@ -134,7 +144,7 @@ export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved 
           <button onClick={onClose} disabled={busy} className="ui-icon-button text-lg" aria-label="閉じる">×</button>
         </div>
 
-        <div className="overflow-auto p-4 space-y-4 max-h-[calc(100dvh-154px)]">
+        <div className="overflow-auto p-4 space-y-4 max-h-[calc(100dvh-154px)]" style={{ backgroundColor: "hsl(var(--card))" }}>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <label className="space-y-1.5">
               <span className="ui-label">投稿先</span>
@@ -172,7 +182,7 @@ export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved 
           </div>
 
           {showQuickTarget && (
-            <div className="rounded-xl border border-border bg-muted/25 p-3 space-y-2">
+            <div className="rounded-xl border border-border p-3 space-y-2" style={{ backgroundColor: "hsl(var(--muted))" }}>
               <p className="text-xs font-medium">投稿先をその場で追加</p>
               <div className="grid grid-cols-[minmax(0,1fr)_120px_auto] gap-2">
                 <input className="ui-input min-w-0" value={newTargetName} onChange={(event) => setNewTargetName(event.target.value)} placeholder="例: Pixiv" />
@@ -189,7 +199,7 @@ export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved 
           )}
 
           {showQuickAccount && targetId > 0 && (
-            <div className="rounded-xl border border-border bg-muted/25 p-3 space-y-2">
+            <div className="rounded-xl border border-border p-3 space-y-2" style={{ backgroundColor: "hsl(var(--muted))" }}>
               <p className="text-xs font-medium">この投稿先のアカウントを追加</p>
               <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
                 <input className="ui-input min-w-0" value={newAccountDisplay} onChange={(event) => setNewAccountDisplay(event.target.value)} placeholder="表示名" />
@@ -223,7 +233,7 @@ export function PostRecordModal({ assetIds, defaultTitle = "", onClose, onSaved 
           {error && <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>}
         </div>
 
-        <div className="min-h-16 px-4 py-3 border-t border-border flex items-center justify-between gap-3 bg-card">
+        <div className="min-h-16 px-4 py-3 border-t border-border flex items-center justify-between gap-3" style={{ backgroundColor: "hsl(var(--card))" }}>
           <p className="text-[11px] text-muted-foreground">画像ファイル自体は変更・移動されません。</p>
           <div className="flex items-center gap-2">
             <button className="ui-secondary-button" onClick={onClose} disabled={busy}>キャンセル</button>

--- a/frontend/src/components/TagPicker.tsx
+++ b/frontend/src/components/TagPicker.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { createTag, setAssetTags } from "../api/client";
+import type { TagDTO } from "../api/client";
+
+const MAX_VISIBLE_CANDIDATES = 80;
+const tagCollator = new Intl.Collator("ja", { sensitivity: "base", numeric: true });
+
+interface TagPickerProps {
+  assetId: number;
+  tags: TagDTO[];
+  assignedTags: TagDTO[];
+  onAssignedTagsChange: (tags: TagDTO[]) => void;
+  onChanged?: () => void | Promise<void>;
+}
+
+function normalized(value: string): string {
+  return value.trim().toLocaleLowerCase("ja-JP");
+}
+
+export function TagPicker({ assetId, tags, assignedTags, onAssignedTagsChange, onChanged }: TagPickerProps) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [newColor, setNewColor] = useState("#6366f1");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const assignedIds = useMemo(() => new Set(assignedTags.map((tag) => tag.id)), [assignedTags]);
+  const searchKey = normalized(search);
+
+  const candidates = useMemo(() => {
+    const filtered = tags.filter((tag) => {
+      if (assignedIds.has(tag.id)) return false;
+      return !searchKey || normalized(tag.name).includes(searchKey);
+    });
+    filtered.sort((a, b) => tagCollator.compare(a.name, b.name));
+    return filtered;
+  }, [assignedIds, searchKey, tags]);
+
+  const visibleCandidates = candidates.slice(0, MAX_VISIBLE_CANDIDATES);
+  const exactTag = useMemo(
+    () => tags.find((tag) => normalized(tag.name) === searchKey),
+    [searchKey, tags]
+  );
+  const canCreate = search.trim().length > 0 && !exactTag;
+
+  const persist = async (nextTags: TagDTO[]) => {
+    if (assetId <= 0 || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await setAssetTags(assetId, nextTags.map((tag) => tag.id));
+      onAssignedTagsChange(nextTags);
+      await onChanged?.();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : String(saveError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const addTag = async (tag: TagDTO) => {
+    if (assignedIds.has(tag.id)) return;
+    await persist([...assignedTags, tag]);
+    setSearch("");
+  };
+
+  const removeTag = async (tagId: number) => {
+    await persist(assignedTags.filter((tag) => tag.id !== tagId));
+  };
+
+  const createAndAssign = async () => {
+    const name = search.trim();
+    if (!name || busy) return;
+    if (exactTag) {
+      if (!assignedIds.has(exactTag.id)) await addTag(exactTag);
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await createTag(name, newColor);
+      if (!created) throw new Error("タグを作成できませんでした。同名タグがないか確認してください。");
+      const nextTags = [...assignedTags, created];
+      await setAssetTags(assetId, nextTags.map((tag) => tag.id));
+      onAssignedTagsChange(nextTags);
+      setSearch("");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["tags"] }),
+        Promise.resolve(onChanged?.()),
+      ]);
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : String(createError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleEnter = async () => {
+    if (!search.trim() || busy) return;
+    if (exactTag && !assignedIds.has(exactTag.id)) {
+      await addTag(exactTag);
+      return;
+    }
+    if (canCreate) await createAndAssign();
+  };
+
+  return (
+    <div className="space-y-2.5">
+      <div>
+        <div className="mb-1.5 flex items-center justify-between gap-2">
+          <span className="text-[10px] font-medium text-muted-foreground">付与済み {assignedTags.length}件</span>
+          {assignedTags.length > 0 && <span className="text-[10px] text-muted-foreground/70">クリックで解除</span>}
+        </div>
+        {assignedTags.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {assignedTags
+              .slice()
+              .sort((a, b) => tagCollator.compare(a.name, b.name))
+              .map((tag) => (
+                <button
+                  key={tag.id}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void removeTag(tag.id)}
+                  className="h-7 max-w-full px-2.5 rounded-full border border-primary/40 bg-primary/15 text-[11px] text-foreground inline-flex items-center gap-1.5"
+                  title={`「${tag.name}」を外す`}
+                >
+                  <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color || "transparent" }} />
+                  <span className="truncate">{tag.name}</span>
+                  <span className="text-muted-foreground">×</span>
+                </button>
+              ))}
+          </div>
+        ) : (
+          <p className="text-[11px] text-muted-foreground">この画像にはまだタグがありません。</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="ui-label" htmlFor={`tag-search-${assetId}`}>タグを検索・追加</label>
+        <div className="flex gap-1.5">
+          <input
+            id={`tag-search-${assetId}`}
+            className="ui-input min-w-0 flex-1"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void handleEnter();
+              }
+            }}
+            placeholder="タグ名を入力…"
+            autoComplete="off"
+          />
+          {canCreate && (
+            <input
+              type="color"
+              value={newColor}
+              onChange={(event) => setNewColor(event.target.value)}
+              className="w-8 h-8 rounded-lg border border-border bg-transparent flex-shrink-0"
+              aria-label="新しいタグの色"
+              title="新しいタグの色"
+            />
+          )}
+        </div>
+      </div>
+
+      {canCreate && (
+        <button
+          type="button"
+          className="ui-primary-button w-full justify-center"
+          disabled={busy}
+          onClick={() => void createAndAssign()}
+        >
+          ＋ 「{search.trim()}」を新規作成して付与
+        </button>
+      )}
+
+      {tags.length > 0 && (
+        <div className="rounded-lg border border-border bg-muted/15 overflow-hidden">
+          <div className="px-2.5 py-1.5 border-b border-border flex items-center justify-between text-[10px] text-muted-foreground">
+            <span>{searchKey ? `候補 ${candidates.length}件` : `未付与 ${candidates.length}件`}</span>
+            {candidates.length > MAX_VISIBLE_CANDIDATES && <span>上位{MAX_VISIBLE_CANDIDATES}件を表示</span>}
+          </div>
+          <div className="max-h-40 overflow-y-auto p-1">
+            {visibleCandidates.map((tag) => (
+              <button
+                key={tag.id}
+                type="button"
+                disabled={busy}
+                onClick={() => void addTag(tag)}
+                className="w-full min-h-8 px-2 rounded-md flex items-center gap-2 text-left text-[11px] hover:bg-accent"
+              >
+                <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color || "transparent" }} />
+                <span className="min-w-0 flex-1 truncate">{tag.name}</span>
+                <span className="text-muted-foreground">＋</span>
+              </button>
+            ))}
+            {visibleCandidates.length === 0 && !canCreate && (
+              <p className="px-2 py-3 text-center text-[11px] text-muted-foreground">該当する未付与タグはありません</p>
+            )}
+          </div>
+          {candidates.length > MAX_VISIBLE_CANDIDATES && (
+            <p className="px-2.5 py-1.5 border-t border-border text-[10px] text-muted-foreground">タグ名を入力して絞り込むと、残りの候補もすぐ探せます。</p>
+          )}
+        </div>
+      )}
+
+      {error && <p className="text-[11px] leading-relaxed text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ViewerGridV2.tsx
+++ b/frontend/src/components/ViewerGridV2.tsx
@@ -109,6 +109,10 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
   const virtualItems = virtualizer.getVirtualItems();
 
   useEffect(() => {
+    virtualizer.measure();
+  }, [columns, state.thumbnailSize, state.viewMode, virtualizer]);
+
+  useEffect(() => {
     if (!hasNextPage || isFetchingNextPage) return;
     const last = virtualItems[virtualItems.length - 1];
     const maximum = state.viewMode === "grid" ? rowCount : assets.length;
@@ -218,7 +222,7 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
             <div className="max-w-sm rounded-2xl border border-dashed border-border p-8 text-center">
               <p className="text-sm font-semibold">{hasFilters ? "条件に一致する画像がありません" : "画像が見つかりません"}</p>
               <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                {hasFilters ? "上部の絞り込み条件を解除して確認してください。" : "対象フォルダーを再スキャンしてください。"}
+                {hasFilters ? "上部の絞り込み条件を解除して確認してください。" : "画像フォルダーの変更は自動で確認されます。必要なら左側から再スキャンもできます。"}
               </p>
             </div>
           </div>
@@ -275,6 +279,7 @@ function GridCard({
         width={size}
         height={size}
         fit="cover"
+        priority="high"
         alt={asset.fileName}
       />
       <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/85 via-black/25 to-transparent pointer-events-none" />
@@ -328,6 +333,7 @@ function ListRow({
         width={44}
         height={44}
         fit="cover"
+        priority="high"
         alt={asset.fileName}
         className="rounded-lg flex-shrink-0"
       />

--- a/frontend/src/components/ViewerGridV2.tsx
+++ b/frontend/src/components/ViewerGridV2.tsx
@@ -42,11 +42,13 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
     sortDesc: state.sortDesc,
     statusLabel: state.filterStatusLabel || undefined,
     rating: state.filterRating || undefined,
+    tagIds: state.filterTagIds.length > 0 ? state.filterTagIds : undefined,
     offset,
     limit: PAGE_SIZE,
   }), [
     state.filterRating,
     state.filterStatusLabel,
+    state.filterTagIds,
     state.searchQuery,
     state.selectedFolderPath,
     state.selectedLibraryId,
@@ -72,6 +74,7 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
       state.sortDesc,
       state.filterStatusLabel,
       state.filterRating,
+      state.filterTagIds.join(","),
     ],
     queryFn: async ({ pageParam = 0 }) => {
       const result = await listAssets(buildQuery(Number(pageParam)));
@@ -141,7 +144,13 @@ export function ViewerGridV2({ onSelectAsset, onAssetsLoaded }: ViewerGridV2Prop
     );
   }
 
-  const hasFilters = !!(state.selectedFolderPath || state.searchQuery || state.filterStatusLabel || state.filterRating > 0);
+  const hasFilters = !!(
+    state.selectedFolderPath ||
+    state.searchQuery ||
+    state.filterStatusLabel ||
+    state.filterRating > 0 ||
+    state.filterTagIds.length > 0
+  );
 
   return (
     <>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -30,6 +30,31 @@
   --ui-font-small: 0.6875rem;
 }
 
+/* Tailwind v4 only generates semantic color utilities from --color-* theme
+   tokens. The UI uses classes such as bg-card, text-muted-foreground and
+   border-border throughout, so map the runtime HSL variables explicitly. */
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+}
+
 * {
   border-color: hsl(var(--border));
   box-sizing: border-box;
@@ -259,175 +284,101 @@ textarea:focus-visible {
 .ui-segmented button.active {
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.2);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
+}
+
+.toolbar-v2 {
+  min-width: 0;
+}
+
+.toolbar-primary-row,
+.toolbar-controls-row,
+.toolbar-filter-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .toolbar-primary-row {
-  min-height: 3rem;
-  display: grid;
-  grid-template-columns: 2rem minmax(7rem, 11rem) minmax(14rem, 1fr);
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem 0.25rem;
+  min-height: 2.75rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
 }
 
 .toolbar-controls-row {
-  min-height: 2.75rem;
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.75rem 0.5rem;
+  min-height: 2.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.375rem;
+  border-top: 1px solid hsl(var(--border) / 0.55);
   overflow-x: auto;
-  overflow-y: hidden;
   scrollbar-width: thin;
 }
 
-.toolbar-controls-row > * {
-  flex-shrink: 0;
+.toolbar-filter-row {
+  min-height: 2.25rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.375rem;
+  border-top: 1px solid hsl(var(--border) / 0.45);
+  overflow-x: auto;
 }
 
-.toolbar-filter-row {
-  min-height: 2rem;
-  padding: 0 0.75rem 0.5rem;
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  flex-wrap: wrap;
+.toolbar-library {
+  width: clamp(8rem, 14vw, 12rem);
+  flex: 0 1 auto;
 }
 
 .filter-chip {
-  max-width: 15rem;
-  min-height: 1.625rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 999px;
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
-  font-size: 0.625rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.viewer-control {
-  min-width: 2.25rem;
-  height: 2.25rem;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  border: 1px solid rgb(255 255 255 / 0.12);
-  border-radius: 0.625rem;
-  background: rgb(24 24 27 / 0.82);
-  color: white;
-}
-
-.viewer-control:hover {
-  background: rgb(39 39 42 / 0.95);
-}
-
-.viewer-nav {
-  position: absolute;
-  top: 50%;
-  z-index: 20;
-  width: 3rem;
-  height: 3rem;
-  transform: translateY(-50%);
-  border: 1px solid rgb(255 255 255 / 0.12);
+  min-height: 1.625rem;
+  max-width: 14rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid hsl(var(--border));
   border-radius: 999px;
-  background: rgb(24 24 27 / 0.72);
-  color: white;
-  font-size: 2rem;
-  line-height: 1;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  font-size: 0.625rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.viewer-nav:hover:not(:disabled) {
-  background: rgb(39 39 42 / 0.95);
+.filter-chip:hover {
+  background: hsl(var(--accent));
 }
 
 @media (max-width: 1080px) {
-  :root {
-    --sidebar-width: 13.5rem;
-    --detail-width: min(22rem, 88vw);
-  }
-
   .app-detail-panel {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0 0 0 auto;
     z-index: 40;
-    min-width: min(20.5rem, 88vw);
-    max-width: 88vw;
-    box-shadow: -16px 0 40px rgb(0 0 0 / 0.45);
-  }
-
-  .toolbar-primary-row {
-    grid-template-columns: 2rem minmax(6rem, 9rem) minmax(12rem, 1fr);
+    box-shadow: -18px 0 40px rgba(0, 0, 0, 0.45);
   }
 }
 
-@media (max-width: 820px) {
+@media (max-width: 900px) {
   :root {
-    --sidebar-width: 12.5rem;
+    --sidebar-width: 13.5rem;
+    --detail-width: min(22rem, calc(100vw - 4rem));
   }
 
+  .toolbar-controls-row {
+    gap: 0.375rem;
+  }
+}
+
+@media (max-width: 760px) {
   .app-sidebar {
-    min-width: 11rem;
+    position: absolute;
+    inset: 0 auto 0 0;
+    z-index: 50;
+    box-shadow: 14px 0 30px rgba(0, 0, 0, 0.4);
   }
 
   .toolbar-library {
     display: none;
   }
-
-  .toolbar-primary-row {
-    grid-template-columns: 2rem minmax(10rem, 1fr);
-  }
-}
-
-@media (max-width: 620px) {
-  .app-sidebar {
-    width: min(11.5rem, 42vw);
-    min-width: 10rem;
-  }
-
-  .app-detail-panel {
-    width: min(21rem, 94vw);
-    min-width: 0;
-    max-width: 94vw;
-  }
-
-  .toolbar-primary-row {
-    padding-inline: 0.5rem;
-    grid-template-columns: 2rem minmax(8rem, 1fr);
-  }
-
-  .toolbar-controls-row,
-  .toolbar-filter-row {
-    padding-inline: 0.5rem;
-  }
-}
-
-::selection {
-  background: hsl(var(--foreground) / 0.22);
-}
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: hsl(var(--muted));
-  border-radius: 999px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.65);
-  border: 2px solid transparent;
-  background-clip: padding-box;
 }

--- a/frontend/src/test/AssetDetailPanel.test.tsx
+++ b/frontend/src/test/AssetDetailPanel.test.tsx
@@ -18,6 +18,7 @@ vi.mock("../components/PostRecordModal", () => ({
 }));
 
 vi.mock("../api/client", () => ({
+  createTag: vi.fn(),
   getAssetDetail: vi.fn(),
   getPostRecordsByAsset: vi.fn(async () => []),
   listTags: vi.fn(async () => []),

--- a/frontend/src/test/BulkActionsBar.test.tsx
+++ b/frontend/src/test/BulkActionsBar.test.tsx
@@ -35,11 +35,11 @@ describe("BulkActionsBar", () => {
     expect(screen.getByText("公開済み")).toBeInTheDocument();
   });
 
-  it("お気に入り・投稿記録・削除・選択解除を表示する", () => {
+  it("お気に入り・投稿記録・ファイル削除・選択解除を表示する", () => {
     renderBar();
     expect(screen.getByText("★ お気に入り")).toBeInTheDocument();
     expect(screen.getByText("＋ 投稿記録")).toBeInTheDocument();
-    expect(screen.getByText("一覧から削除")).toBeInTheDocument();
+    expect(screen.getByText("画像ファイルを削除")).toBeInTheDocument();
     expect(screen.getByText("選択解除")).toBeInTheDocument();
   });
 
@@ -67,11 +67,11 @@ describe("BulkActionsBar", () => {
     expect(onClear).toHaveBeenCalledOnce();
   });
 
-  it("一覧から削除を実行できる", async () => {
+  it("画像ファイル削除を実行できる", async () => {
     const onDelete = vi.fn();
     renderBar({ onDelete });
     const user = userEvent.setup();
-    await user.click(screen.getByText("一覧から削除"));
+    await user.click(screen.getByText("画像ファイルを削除"));
     expect(onDelete).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/test/MemoryImage.test.tsx
+++ b/frontend/src/test/MemoryImage.test.tsx
@@ -1,0 +1,70 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils/imagePipeline", () => ({
+  loadMemoryBitmap: vi.fn(),
+}));
+
+vi.mock("../api/client", () => ({
+  getLocalImageUrl: (path: string) => `/local?path=${encodeURIComponent(path)}`,
+}));
+
+import { loadMemoryBitmap } from "../utils/imagePipeline";
+import { MemoryImage } from "../components/MemoryImage";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function bitmap(width: number, height: number): ImageBitmap {
+  return { width, height } as ImageBitmap;
+}
+
+describe("MemoryImage", () => {
+  beforeEach(() => {
+    vi.mocked(loadMemoryBitmap).mockReset();
+    Object.defineProperty(globalThis, "createImageBitmap", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({
+        clearRect: vi.fn(),
+        drawImage: vi.fn(),
+      })),
+    });
+  });
+
+  it("表示サイズを大へ変更しても新しいデコード完了まで既存canvasを消さない", async () => {
+    const larger = deferred<ImageBitmap>();
+    vi.mocked(loadMemoryBitmap)
+      .mockResolvedValueOnce(bitmap(180, 180))
+      .mockImplementationOnce(() => larger.promise);
+
+    const { container, rerender } = render(
+      <MemoryImage filePath="C:\\images\\a.png" width={180} height={180} alt="a.png" />
+    );
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+
+    await waitFor(() => expect(canvas.width).toBe(180));
+    expect(canvas.height).toBe(180);
+
+    rerender(<MemoryImage filePath="C:\\images\\a.png" width={260} height={260} alt="a.png" />);
+
+    expect(canvas.style.width).toBe("260px");
+    expect(canvas.style.height).toBe("260px");
+    expect(canvas.width).toBe(180);
+    expect(canvas.height).toBe(180);
+
+    larger.resolve(bitmap(260, 260));
+    await waitFor(() => expect(canvas.width).toBe(260));
+    expect(canvas.height).toBe(260);
+  });
+});

--- a/frontend/src/test/MemoryImage.test.tsx
+++ b/frontend/src/test/MemoryImage.test.tsx
@@ -2,6 +2,13 @@ import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../utils/imagePipeline", () => ({
+  computeCoverCrop: vi.fn((sourceWidth: number, sourceHeight: number) => ({
+    x: 0,
+    y: 0,
+    width: sourceWidth,
+    height: sourceHeight,
+  })),
+  getCachedMemoryBitmap: vi.fn(() => null),
   loadMemoryBitmap: vi.fn(),
 }));
 
@@ -9,7 +16,7 @@ vi.mock("../api/client", () => ({
   getLocalImageUrl: (path: string) => `/local?path=${encodeURIComponent(path)}`,
 }));
 
-import { loadMemoryBitmap } from "../utils/imagePipeline";
+import { getCachedMemoryBitmap, loadMemoryBitmap } from "../utils/imagePipeline";
 import { MemoryImage } from "../components/MemoryImage";
 
 function deferred<T>() {
@@ -27,8 +34,13 @@ function bitmap(width: number, height: number): ImageBitmap {
 }
 
 describe("MemoryImage", () => {
+  let drawImage: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.mocked(loadMemoryBitmap).mockReset();
+    vi.mocked(getCachedMemoryBitmap).mockReset();
+    vi.mocked(getCachedMemoryBitmap).mockReturnValue(null);
+    drawImage = vi.fn();
     Object.defineProperty(globalThis, "createImageBitmap", {
       configurable: true,
       value: vi.fn(),
@@ -37,7 +49,7 @@ describe("MemoryImage", () => {
       configurable: true,
       value: vi.fn(() => ({
         clearRect: vi.fn(),
-        drawImage: vi.fn(),
+        drawImage,
       })),
     });
   });
@@ -66,5 +78,23 @@ describe("MemoryImage", () => {
     larger.resolve(bitmap(260, 260));
     await waitFor(() => expect(canvas.width).toBe(260));
     expect(canvas.height).toBe(260);
+  });
+
+  it("列組み替えでカードが再マウントされても既存メモリBitmapを即表示する", async () => {
+    const exact = deferred<ImageBitmap>();
+    vi.mocked(getCachedMemoryBitmap).mockReturnValue(bitmap(180, 180));
+    vi.mocked(loadMemoryBitmap).mockImplementation(() => exact.promise);
+
+    const { container } = render(
+      <MemoryImage filePath="C:\\images\\a.png" width={260} height={260} alt="a.png" />
+    );
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+
+    await waitFor(() => expect(canvas.width).toBe(260));
+    expect(canvas.height).toBe(260);
+    expect(drawImage).toHaveBeenCalled();
+
+    exact.resolve(bitmap(260, 260));
+    await waitFor(() => expect(drawImage.mock.calls.length).toBeGreaterThanOrEqual(2));
   });
 });

--- a/frontend/src/test/TagPicker.test.tsx
+++ b/frontend/src/test/TagPicker.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TagDTO } from "../api/client";
+
+vi.mock("../api/client", () => ({
+  createTag: vi.fn(),
+  setAssetTags: vi.fn(async () => undefined),
+}));
+
+import { createTag, setAssetTags } from "../api/client";
+import { TagPicker } from "../components/TagPicker";
+
+function renderPicker(tags: TagDTO[], assignedTags: TagDTO[] = [], onAssignedTagsChange = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <TagPicker
+        assetId={42}
+        tags={tags}
+        assignedTags={assignedTags}
+        onAssignedTagsChange={onAssignedTagsChange}
+      />
+    </QueryClientProvider>
+  );
+  return onAssignedTagsChange;
+}
+
+function makeTag(id: number, name: string): TagDTO {
+  return { id, name, color: "#6366f1" } as TagDTO;
+}
+
+describe("TagPicker", () => {
+  beforeEach(() => {
+    vi.mocked(createTag).mockReset();
+    vi.mocked(setAssetTags).mockClear();
+  });
+
+  it("大量タグでは候補を80件に制限し、検索でそれ以外へ到達できる", async () => {
+    const tags = Array.from({ length: 120 }, (_, index) => makeTag(index + 1, `tag-${String(index + 1).padStart(3, "0")}`));
+    renderPicker(tags, [tags[0]]);
+
+    expect(screen.getByText("未付与 119件")).toBeInTheDocument();
+    expect(screen.getByText("上位80件を表示")).toBeInTheDocument();
+    expect(screen.queryByText("tag-120")).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("タグを検索・追加"), "tag-120");
+
+    expect(screen.getByText("候補 1件")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tag-120/ })).toBeInTheDocument();
+  });
+
+  it("検索語から新規タグを作成して同じ画像へ即付与する", async () => {
+    const assigned = makeTag(1, "existing");
+    const created = makeTag(99, "new-tag");
+    const onAssignedTagsChange = vi.fn();
+    vi.mocked(createTag).mockResolvedValue(created);
+    renderPicker([assigned], [assigned], onAssignedTagsChange);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("タグを検索・追加"), "new-tag");
+    await user.click(screen.getByRole("button", { name: "＋ 「new-tag」を新規作成して付与" }));
+
+    await waitFor(() => expect(createTag).toHaveBeenCalledWith("new-tag", "#6366f1"));
+    expect(setAssetTags).toHaveBeenCalledWith(42, [1, 99]);
+    expect(onAssignedTagsChange).toHaveBeenCalledWith([assigned, created]);
+  });
+});

--- a/frontend/src/utils/imagePipeline.ts
+++ b/frontend/src/utils/imagePipeline.ts
@@ -27,6 +27,13 @@ const MAX_CONCURRENT_DECODES = 4;
 interface CacheEntry {
   bitmap: ImageBitmap;
   bytes: number;
+  filePath: string;
+  modifiedAtFs: string;
+  sourceWidth: number;
+  sourceHeight: number;
+  targetWidth: number;
+  targetHeight: number;
+  fit: ImageFit;
 }
 
 interface DecodeWaiter {
@@ -122,7 +129,7 @@ function evictToBudget(): void {
   }
 }
 
-function cacheBitmap(key: string, bitmap: ImageBitmap): void {
+function cacheBitmap(key: string, bitmap: ImageBitmap, request: ImageBitmapRequest): void {
   const bytes = bitmap.width * bitmap.height * 4;
   const previous = cache.get(key);
   if (previous) {
@@ -130,9 +137,57 @@ function cacheBitmap(key: string, bitmap: ImageBitmap): void {
     if (previous.bitmap !== bitmap) previous.bitmap.close();
     cache.delete(key);
   }
-  cache.set(key, { bitmap, bytes });
+  cache.set(key, {
+    bitmap,
+    bytes,
+    filePath: request.filePath,
+    modifiedAtFs: request.modifiedAtFs ?? "",
+    sourceWidth: request.sourceWidth ?? 0,
+    sourceHeight: request.sourceHeight ?? 0,
+    targetWidth: Math.max(1, Math.round(request.targetWidth)),
+    targetHeight: Math.max(1, Math.round(request.targetHeight)),
+    fit: request.fit,
+  });
   cacheBytes += bytes;
   evictToBudget();
+}
+
+// Returns the nearest already-decoded representation of the same source image.
+// This is intentionally synchronous: a remounted grid card can paint the old
+// in-memory preview immediately while the requested larger bitmap is decoded.
+export function getCachedMemoryBitmap(request: ImageBitmapRequest): ImageBitmap | null {
+  const sourceWidth = request.sourceWidth ?? 0;
+  const sourceHeight = request.sourceHeight ?? 0;
+  const modifiedAtFs = request.modifiedAtFs ?? "";
+  const targetWidth = Math.max(1, Math.round(request.targetWidth));
+  const targetHeight = Math.max(1, Math.round(request.targetHeight));
+
+  let bestKey: string | null = null;
+  let bestEntry: CacheEntry | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const [key, entry] of cache) {
+    if (
+      entry.filePath !== request.filePath ||
+      entry.modifiedAtFs !== modifiedAtFs ||
+      entry.sourceWidth !== sourceWidth ||
+      entry.sourceHeight !== sourceHeight ||
+      entry.fit !== request.fit
+    ) {
+      continue;
+    }
+
+    const distance = Math.abs(entry.targetWidth - targetWidth) + Math.abs(entry.targetHeight - targetHeight);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestKey = key;
+      bestEntry = entry;
+    }
+  }
+
+  if (!bestKey || !bestEntry) return null;
+  touchCache(bestKey, bestEntry);
+  return bestEntry.bitmap;
 }
 
 function wakeNextDecode(): void {
@@ -236,7 +291,7 @@ export async function loadMemoryBitmap(request: ImageBitmapRequest): Promise<Ima
     }
     const blob = await response.blob();
     const bitmap = await createSizedBitmap(blob, request);
-    cacheBitmap(key, bitmap);
+    cacheBitmap(key, bitmap, request);
     return bitmap;
   }, request.priority ?? "normal");
 

--- a/internal/commands/asset_file_delete.go
+++ b/internal/commands/asset_file_delete.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+)
+
+type DeleteAssetFilesResult struct {
+	DeletedCount int      `json:"deletedCount"`
+	FailedCount  int      `json:"failedCount"`
+	DeletedIDs   []int64  `json:"deletedIds"`
+	FailedIDs    []int64  `json:"failedIds"`
+	Errors       []string `json:"errors,omitempty"`
+}
+
+// DeleteAssetFiles removes the original files and only then removes their
+// database rows. Missing files are treated as already deleted and their stale
+// database rows are cleaned up. A filesystem failure leaves the DB row intact.
+func (c *AppCommands) DeleteAssetFiles(ids []int64) *DeleteAssetFilesResult {
+	result := &DeleteAssetFilesResult{}
+	seen := make(map[int64]struct{}, len(ids))
+
+	for _, id := range ids {
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		asset, err := c.assetRepo.GetByID(id)
+		if err != nil {
+			result.FailedCount++
+			result.FailedIDs = append(result.FailedIDs, id)
+			result.Errors = append(result.Errors, fmt.Sprintf("asset %d: %v", id, err))
+			continue
+		}
+		if asset == nil {
+			continue
+		}
+
+		if err := os.Remove(asset.FilePath); err != nil && !os.IsNotExist(err) {
+			result.FailedCount++
+			result.FailedIDs = append(result.FailedIDs, id)
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", asset.FilePath, err))
+			continue
+		}
+
+		if err := c.assetRepo.Delete(id); err != nil {
+			result.FailedCount++
+			result.FailedIDs = append(result.FailedIDs, id)
+			result.Errors = append(result.Errors, fmt.Sprintf("database cleanup for %s: %v", asset.FilePath, err))
+			continue
+		}
+
+		result.DeletedCount++
+		result.DeletedIDs = append(result.DeletedIDs, id)
+	}
+
+	return result
+}

--- a/internal/commands/asset_file_delete_test.go
+++ b/internal/commands/asset_file_delete_test.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kataage/lumine/internal/domain"
+	"github.com/kataage/lumine/internal/infrastructure/db"
+	"github.com/kataage/lumine/internal/infrastructure/scanner"
+)
+
+func newDeleteTestCommands(t *testing.T) (*AppCommands, *db.DB, *domain.Library) {
+	t.Helper()
+	database, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	libraryRepo := db.NewLibraryRepo(database)
+	root := t.TempDir()
+	library, err := libraryRepo.Create("delete-test", root)
+	if err != nil {
+		database.Close()
+		t.Fatal(err)
+	}
+	scanSvc := scanner.NewScanner(db.NewAssetRepo(database), libraryRepo, db.NewJobLogRepo(database))
+	return New(database, scanSvc), database, library
+}
+
+func TestDeleteAssetFilesRemovesOriginalAndDatabaseRowOnce(t *testing.T) {
+	commands, database, library := newDeleteTestCommands(t)
+	defer database.Close()
+
+	path := filepath.Join(library.RootPath, "delete-me.png")
+	if err := os.WriteFile(path, []byte("image-data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	id, err := commands.assetRepo.Create(&domain.Asset{
+		LibraryID:   library.ID,
+		FolderPath:  library.RootPath,
+		FileName:    filepath.Base(path),
+		FilePath:    path,
+		Extension:   ".png",
+		FileSize:    10,
+		ThumbStatus: domain.ThumbStatusNone,
+		StatusLabel: domain.StatusUnsorted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := commands.DeleteAssetFiles([]int64{id, id})
+	if result.DeletedCount != 1 || result.FailedCount != 0 || len(result.DeletedIDs) != 1 {
+		t.Fatalf("delete result = %+v", result)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("original file still exists or stat failed unexpectedly: %v", err)
+	}
+	asset, err := commands.assetRepo.GetByID(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset != nil {
+		t.Fatal("asset row still exists after file deletion")
+	}
+}
+
+func TestDeleteAssetFilesCleansStaleMissingFileRow(t *testing.T) {
+	commands, database, library := newDeleteTestCommands(t)
+	defer database.Close()
+
+	path := filepath.Join(library.RootPath, "already-missing.png")
+	id, err := commands.assetRepo.Create(&domain.Asset{
+		LibraryID:   library.ID,
+		FolderPath:  library.RootPath,
+		FileName:    filepath.Base(path),
+		FilePath:    path,
+		Extension:   ".png",
+		ThumbStatus: domain.ThumbStatusNone,
+		StatusLabel: domain.StatusUnsorted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := commands.DeleteAssetFiles([]int64{id})
+	if result.DeletedCount != 1 || result.FailedCount != 0 {
+		t.Fatalf("delete result = %+v", result)
+	}
+	asset, err := commands.assetRepo.GetByID(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset != nil {
+		t.Fatal("stale asset row still exists")
+	}
+}

--- a/internal/commands/library_sync.go
+++ b/internal/commands/library_sync.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kataage/lumine/internal/infrastructure/scanner"
+)
+
+// SyncLibraryViewer performs a silent incremental reconciliation for the
+// currently viewed library. Unlike the manual scan path it does not emit
+// progress events, so the frontend can ignore no-op checks and only refresh
+// when files were actually added, changed, or removed.
+func (c *AppCommands) SyncLibraryViewer(libraryID int64) (*scanner.SyncResult, error) {
+	library, err := c.libraryRepo.GetByID(libraryID)
+	if err != nil || library == nil {
+		return nil, fmt.Errorf("library not found: %d", libraryID)
+	}
+	if !library.IsEnabled {
+		return nil, fmt.Errorf("library is disabled: %d", libraryID)
+	}
+
+	result, err := c.scanSvc.SyncLibrary(library, c.GetExcludedDirs(libraryID))
+	if err != nil && strings.Contains(err.Error(), "scan already in progress") {
+		return &scanner.SyncResult{LibraryID: libraryID}, nil
+	}
+	return result, err
+}

--- a/internal/infrastructure/db/asset_sync_repo.go
+++ b/internal/infrastructure/db/asset_sync_repo.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/kataage/lumine/internal/domain"
+)
+
+// GetSyncFilePathsMap is the lightweight counterpart of GetAllFilePathsMap.
+// Background reconciliation runs frequently, so it deliberately avoids loading
+// hashes and EXIF strings that are never needed to decide whether a file
+// changed. User-managed state needed by UpdateBatch is preserved.
+func (r *AssetRepo) GetSyncFilePathsMap(libraryID int64) (map[string]*domain.Asset, error) {
+	rows, err := r.db.Query(
+		"SELECT id, library_id, folder_path, file_name, file_path, extension, file_size, modified_at_fs, width, height, mime_type, thumb_status, metadata_loaded, rating, status_label, is_favorite, color_label FROM assets WHERE library_id = ?",
+		libraryID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get sync file paths: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]*domain.Asset)
+	for rows.Next() {
+		var asset domain.Asset
+		var modifiedAtFS, mimeType, colorLabel sql.NullString
+		if err := rows.Scan(
+			&asset.ID,
+			&asset.LibraryID,
+			&asset.FolderPath,
+			&asset.FileName,
+			&asset.FilePath,
+			&asset.Extension,
+			&asset.FileSize,
+			&modifiedAtFS,
+			&asset.Width,
+			&asset.Height,
+			&mimeType,
+			&asset.ThumbStatus,
+			&asset.MetadataLoaded,
+			&asset.Rating,
+			&asset.StatusLabel,
+			&asset.IsFavorite,
+			&colorLabel,
+		); err != nil {
+			return nil, fmt.Errorf("scan sync asset path: %w", err)
+		}
+		if modifiedAtFS.Valid {
+			asset.ModifiedAtFS, _ = timeParse(modifiedAtFS.String)
+		}
+		if mimeType.Valid {
+			asset.MimeType = mimeType.String
+		}
+		if colorLabel.Valid {
+			asset.ColorLabel = colorLabel.String
+		}
+		result[asset.FilePath] = &asset
+	}
+	return result, rows.Err()
+}

--- a/internal/infrastructure/db/folder_repo.go
+++ b/internal/infrastructure/db/folder_repo.go
@@ -42,3 +42,8 @@ func (r *FolderRepo) UpsertFolder(libraryID int64, path, parentPath string) erro
 	)
 	return err
 }
+
+func (r *FolderRepo) DeletePath(libraryID int64, path string) error {
+	_, err := r.db.Exec("DELETE FROM folders WHERE library_id = ? AND path = ?", libraryID, path)
+	return err
+}

--- a/internal/infrastructure/scanner/sync.go
+++ b/internal/infrastructure/scanner/sync.go
@@ -1,11 +1,16 @@
 package scanner
 
-import "github.com/kataage/lumine/internal/domain"
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kataage/lumine/internal/domain"
+)
 
 // SyncResult is the compact result used by the viewer's silent background sync.
-// ScanLibrary already skips unchanged files using size + mtime, so the silent
-// sync reuses that path while avoiding UI progress events and full refreshes
-// when the filesystem has not changed.
 type SyncResult struct {
 	LibraryID    int64 `json:"libraryId"`
 	ScannedCount int   `json:"scannedCount"`
@@ -17,42 +22,174 @@ type SyncResult struct {
 	Changed      bool  `json:"changed"`
 }
 
-// SyncLibrary performs the same cheap incremental filesystem walk as a manual
-// scan, but returns a delta summary instead of emitting progress events.
+// SyncLibrary performs a lightweight reconciliation without creating job-log
+// rows, emitting scan progress events, or touching unchanged DB records. It is
+// intended for frequent viewer checks while the app is open.
 func (s *Scanner) SyncLibrary(library *domain.Library, excludedDirs []string) (*SyncResult, error) {
-	before, err := s.assetRepo.GetAllFilePathsMap(library.ID)
+	if !s.scanning.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("scan already in progress")
+	}
+	defer s.scanning.Store(false)
+	s.cancelled.Store(false)
+
+	result := &SyncResult{LibraryID: library.ID}
+	existingMap, err := s.assetRepo.GetAllFilePathsMap(library.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("preload existing assets: %w", err)
 	}
 
-	var final ScanProgress
-	if err := s.ScanLibrary(library, excludedDirs, func(progress ScanProgress) {
-		final = progress
-	}); err != nil {
-		return nil, err
+	excludedSet := make(map[string]bool, len(excludedDirs))
+	for _, path := range excludedDirs {
+		excludedSet[strings.ToLower(path)] = true
+	}
+	exts := s.getExtensions()
+	seenFolders := make(map[string]struct{})
+
+	var newAssets []*domain.Asset
+	var updatedAssets []*domain.Asset
+	const batchSize = 250
+
+	flushNew := func() {
+		if len(newAssets) == 0 {
+			return
+		}
+		if err := s.assetRepo.CreateBatch(newAssets); err != nil {
+			slog.Warn("silent sync batch create failed", "error", err)
+			result.FailedCount += len(newAssets)
+		} else {
+			result.AddedCount += len(newAssets)
+		}
+		newAssets = newAssets[:0]
 	}
 
-	after, err := s.assetRepo.GetAllFilePathsMap(library.ID)
-	if err != nil {
-		return nil, err
+	flushUpdated := func() {
+		if len(updatedAssets) == 0 {
+			return
+		}
+		if err := s.assetRepo.UpdateBatch(updatedAssets); err != nil {
+			slog.Warn("silent sync batch update failed", "error", err)
+			result.FailedCount += len(updatedAssets)
+		} else {
+			result.UpdatedCount += len(updatedAssets)
+		}
+		updatedAssets = updatedAssets[:0]
 	}
 
-	removed := 0
-	for path := range before {
-		if _, exists := after[path]; !exists {
-			removed++
+	walkErr := filepath.Walk(library.RootPath, func(path string, info os.FileInfo, err error) error {
+		if s.cancelled.Load() {
+			return filepath.SkipDir
+		}
+		if err != nil {
+			result.FailedCount++
+			return nil
+		}
+
+		if info.IsDir() {
+			if strings.HasPrefix(info.Name(), ".") || excludedSet[strings.ToLower(path)] {
+				return filepath.SkipDir
+			}
+			seenFolders[path] = struct{}{}
+			if s.folderRepo != nil {
+				parentPath := filepath.Dir(path)
+				if path == library.RootPath {
+					parentPath = ""
+				}
+				if err := s.folderRepo.UpsertFolder(library.ID, path, parentPath); err != nil {
+					result.FailedCount++
+				}
+			}
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if !exts[ext] {
+			return nil
+		}
+
+		result.ScannedCount++
+		existing := existingMap[path]
+		modTime := info.ModTime()
+		if existing != nil {
+			delete(existingMap, path)
+			if !existing.ModifiedAtFS.IsZero() && existing.ModifiedAtFS.Equal(modTime) && existing.FileSize == info.Size() {
+				result.SkippedCount++
+				return nil
+			}
+
+			existing.FileSize = info.Size()
+			existing.ModifiedAtFS = modTime
+			existing.ThumbStatus = domain.ThumbStatusNone
+			existing.MetadataLoaded = false
+			existing.CameraModel = ""
+			existing.LensModel = ""
+			existing.FocalLength = ""
+			existing.Aperture = ""
+			existing.ShutterSpeed = ""
+			existing.ISO = 0
+			existing.ExifDate = ""
+			existing.GPSLatitude = ""
+			existing.GPSLongitude = ""
+			existing.Width, existing.Height, existing.MimeType = readImageConfig(path)
+			updatedAssets = append(updatedAssets, existing)
+			if len(updatedAssets) >= batchSize {
+				flushUpdated()
+			}
+			return nil
+		}
+
+		width, height, mimeType := readImageConfig(path)
+		newAssets = append(newAssets, &domain.Asset{
+			LibraryID:      library.ID,
+			FolderPath:     filepath.Dir(path),
+			FileName:       info.Name(),
+			FilePath:       path,
+			Extension:      ext,
+			FileSize:       info.Size(),
+			ModifiedAtFS:   modTime,
+			Width:          width,
+			Height:         height,
+			MimeType:       mimeType,
+			ThumbStatus:    domain.ThumbStatusNone,
+			MetadataLoaded: false,
+			StatusLabel:    domain.StatusUnsorted,
+		})
+		if len(newAssets) >= batchSize {
+			flushNew()
+		}
+		return nil
+	})
+
+	flushNew()
+	flushUpdated()
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if s.cancelled.Load() {
+		return result, nil
+	}
+
+	for _, missing := range existingMap {
+		if err := s.assetRepo.Delete(missing.ID); err != nil {
+			result.FailedCount++
+			continue
+		}
+		result.RemovedCount++
+	}
+
+	if s.folderRepo != nil {
+		if folders, err := s.folderRepo.GetTreeByLibrary(library.ID); err == nil {
+			for _, folder := range folders {
+				if _, seen := seenFolders[folder.Path]; seen {
+					continue
+				}
+				if err := s.folderRepo.DeletePath(library.ID, folder.Path); err != nil {
+					result.FailedCount++
+				}
+			}
 		}
 	}
 
-	result := &SyncResult{
-		LibraryID:    library.ID,
-		ScannedCount: final.ScannedCount,
-		AddedCount:   final.AddedCount,
-		UpdatedCount: final.UpdatedCount,
-		RemovedCount: removed,
-		SkippedCount: final.SkippedCount,
-		FailedCount:  final.FailedCount,
-	}
 	result.Changed = result.AddedCount > 0 || result.UpdatedCount > 0 || result.RemovedCount > 0
 	return result, nil
 }

--- a/internal/infrastructure/scanner/sync.go
+++ b/internal/infrastructure/scanner/sync.go
@@ -1,0 +1,58 @@
+package scanner
+
+import "github.com/kataage/lumine/internal/domain"
+
+// SyncResult is the compact result used by the viewer's silent background sync.
+// ScanLibrary already skips unchanged files using size + mtime, so the silent
+// sync reuses that path while avoiding UI progress events and full refreshes
+// when the filesystem has not changed.
+type SyncResult struct {
+	LibraryID    int64 `json:"libraryId"`
+	ScannedCount int   `json:"scannedCount"`
+	AddedCount   int   `json:"addedCount"`
+	UpdatedCount int   `json:"updatedCount"`
+	RemovedCount int   `json:"removedCount"`
+	SkippedCount int   `json:"skippedCount"`
+	FailedCount  int   `json:"failedCount"`
+	Changed      bool  `json:"changed"`
+}
+
+// SyncLibrary performs the same cheap incremental filesystem walk as a manual
+// scan, but returns a delta summary instead of emitting progress events.
+func (s *Scanner) SyncLibrary(library *domain.Library, excludedDirs []string) (*SyncResult, error) {
+	before, err := s.assetRepo.GetAllFilePathsMap(library.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var final ScanProgress
+	if err := s.ScanLibrary(library, excludedDirs, func(progress ScanProgress) {
+		final = progress
+	}); err != nil {
+		return nil, err
+	}
+
+	after, err := s.assetRepo.GetAllFilePathsMap(library.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	removed := 0
+	for path := range before {
+		if _, exists := after[path]; !exists {
+			removed++
+		}
+	}
+
+	result := &SyncResult{
+		LibraryID:    library.ID,
+		ScannedCount: final.ScannedCount,
+		AddedCount:   final.AddedCount,
+		UpdatedCount: final.UpdatedCount,
+		RemovedCount: removed,
+		SkippedCount: final.SkippedCount,
+		FailedCount:  final.FailedCount,
+	}
+	result.Changed = result.AddedCount > 0 || result.UpdatedCount > 0 || result.RemovedCount > 0
+	return result, nil
+}

--- a/internal/infrastructure/scanner/sync.go
+++ b/internal/infrastructure/scanner/sync.go
@@ -33,7 +33,7 @@ func (s *Scanner) SyncLibrary(library *domain.Library, excludedDirs []string) (*
 	s.cancelled.Store(false)
 
 	result := &SyncResult{LibraryID: library.ID}
-	existingMap, err := s.assetRepo.GetAllFilePathsMap(library.ID)
+	existingMap, err := s.assetRepo.GetSyncFilePathsMap(library.ID)
 	if err != nil {
 		return nil, fmt.Errorf("preload existing assets: %w", err)
 	}

--- a/internal/infrastructure/scanner/sync.go
+++ b/internal/infrastructure/scanner/sync.go
@@ -169,6 +169,15 @@ func (s *Scanner) SyncLibrary(library *domain.Library, excludedDirs []string) (*
 		return result, nil
 	}
 
+	// Missing-path inference is destructive to DB-side metadata (notes, tags,
+	// post associations cascade from assets). If this reconciliation was only a
+	// partial view of the filesystem because any walk/DB step failed, preserve
+	// unseen rows and retry deletion detection on a later clean pass.
+	if result.FailedCount > 0 {
+		result.Changed = result.AddedCount > 0 || result.UpdatedCount > 0
+		return result, nil
+	}
+
 	for _, missing := range existingMap {
 		if err := s.assetRepo.Delete(missing.ID); err != nil {
 			result.FailedCount++

--- a/internal/infrastructure/scanner/sync_test.go
+++ b/internal/infrastructure/scanner/sync_test.go
@@ -1,0 +1,90 @@
+package scanner
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kataage/lumine/internal/infrastructure/db"
+)
+
+func writeTestPNG(t *testing.T, path string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	if err := png.Encode(file, img); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncLibraryDetectsFilesystemDeltaWithoutJobLogs(t *testing.T) {
+	database, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	assetRepo := db.NewAssetRepo(database)
+	libraryRepo := db.NewLibraryRepo(database)
+	scanner := NewScanner(assetRepo, libraryRepo, db.NewJobLogRepo(database))
+	scanner.SetFolderRepo(db.NewFolderRepo(database))
+
+	root := t.TempDir()
+	library, err := libraryRepo.Create("sync-test", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(root, "new.png")
+	writeTestPNG(t, imagePath)
+
+	first, err := scanner.SyncLibrary(library, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.AddedCount != 1 || !first.Changed {
+		t.Fatalf("first sync = %+v, want one addition", first)
+	}
+
+	second, err := scanner.SyncLibrary(library, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Changed || second.SkippedCount != 1 {
+		t.Fatalf("second sync = %+v, want unchanged/skipped", second)
+	}
+
+	if err := os.Remove(imagePath); err != nil {
+		t.Fatal(err)
+	}
+	third, err := scanner.SyncLibrary(library, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.RemovedCount != 1 || !third.Changed {
+		t.Fatalf("third sync = %+v, want one removal", third)
+	}
+
+	remaining, err := assetRepo.GetAllFilePathsMap(library.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining assets = %d, want 0", len(remaining))
+	}
+
+	var jobLogs int
+	if err := database.QueryRow("SELECT COUNT(*) FROM job_logs").Scan(&jobLogs); err != nil {
+		t.Fatal(err)
+	}
+	if jobLogs != 0 {
+		t.Fatalf("silent sync created %d job log rows, want 0", jobLogs)
+	}
+}

--- a/internal/infrastructure/scanner/sync_test.go
+++ b/internal/infrastructure/scanner/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kataage/lumine/internal/domain"
 	"github.com/kataage/lumine/internal/infrastructure/db"
 )
 
@@ -51,6 +52,49 @@ func TestSyncLibraryDetectsFilesystemDeltaWithoutJobLogs(t *testing.T) {
 	}
 	if first.AddedCount != 1 || !first.Changed {
 		t.Fatalf("first sync = %+v, want one addition", first)
+	}
+
+	asset, err := assetRepo.GetByFilePath(imagePath)
+	if err != nil || asset == nil {
+		t.Fatalf("get added asset: %v, asset=%v", err, asset)
+	}
+	fullAsset, err := assetRepo.GetByID(asset.ID)
+	if err != nil || fullAsset == nil {
+		t.Fatalf("get full asset: %v, asset=%v", err, fullAsset)
+	}
+	fullAsset.Rating = 4
+	fullAsset.StatusLabel = domain.StatusCandidate
+	fullAsset.IsFavorite = true
+	fullAsset.ColorLabel = "blue"
+	if err := assetRepo.Update(fullAsset); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.OpenFile(imagePath, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte{0}); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := scanner.SyncLibrary(library, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.UpdatedCount != 1 || !updated.Changed {
+		t.Fatalf("updated sync = %+v, want one update", updated)
+	}
+	preserved, err := assetRepo.GetByID(asset.ID)
+	if err != nil || preserved == nil {
+		t.Fatalf("get updated asset: %v, asset=%v", err, preserved)
+	}
+	if preserved.Rating != 4 || preserved.StatusLabel != domain.StatusCandidate || !preserved.IsFavorite || preserved.ColorLabel != "blue" {
+		t.Fatalf("user-managed state changed during sync: %+v", preserved)
 	}
 
 	second, err := scanner.SyncLibrary(library, nil)


### PR DESCRIPTION
## 概要

実機フィードバックで判明した、手動再スキャン依存・再描画時の黒画面・大サイズ表示の停止感・画像削除不足に加え、投稿記録モーダルの可読性とタグ運用UXをまとめて改善します。

## 変更内容
### ライブラリ自動差分同期
- 選択中ライブラリをバックグラウンドで差分確認
- 起動後、一定間隔、ウィンドウ復帰、再表示時に確認
- mtime + file size が同じ画像はDB更新も画像デコードも行わずスキップ
- 新規・更新・削除が実際にあった場合だけReact Queryを更新
- silent syncではscan progressイベントやjob_logsを生成しない
- 手動スキャンと競合した場合は安全にスキップして次回再試行
- 走査エラーがある回は削除判定を保留し、一時的なI/O障害でDB登録を消さない
- 削除されたフォルダー情報も同期

### 再スキャン・表示サイズ変更時の黒画面抑止
- 新サイズのImageBitmap準備前にcanvasをリサイズ/クリアしない
- 既存プレビューを表示したまま新しい解像度へ順次差し替え
- グリッド再構成でカードが再マウントされても、同じ画像の既存メモリBitmapを即時プレースホルダー表示
- 仮想化で実際に表示中の画像をhigh priority decodeへ
- サムネイルサイズ変更時にvirtualizerを再計測

### 元画像ファイル削除
- 単体選択・複数選択の両方に対応
- 「元に戻せない」確認ダイアログを必須化
- ファイル削除成功後にだけDB登録を削除
- 部分失敗は成功/失敗件数とエラーを表示
- 既に外部で消されているファイルは古いDB行を整理

### 投稿記録モーダルの可読性
- モーダル本体を完全不透明化し、背面画像が内容面へ透けないよう固定
- 背景は暗幕として分離し、文字・フォームとのコントラストを確保
- ヘッダー・本文・フッター・追加フォームも不透明な面として表示

### タグ運用UX
- 右詳細パネルからタグを検索・付与・解除
- 検索語と同名タグがなければ、その場で新規タグを作成して即付与
- 付与済みタグは常に上部へ固定表示
- 未付与候補はスクロール領域化し、80件まで表示。大量タグでは検索で即絞り込み
- 左タグ管理画面にタグ名検索・日本語/数字対応ソート・総件数表示
- 管理画面は200件まで表示し、大量タグ時は検索前提でサイドバーの無制限伸長を防止
- 左タグ一覧をクリックすると画像一覧をタグで絞り込み
- 複数タグ絞り込みに対応し、選択中タグを上へ寄せる
- ツールバーにタグ絞り込み解除チップを表示

## 回帰テスト
- silent sync: 新規追加 → no-op再確認 → 外部削除を検出
- silent syncがjob_logsを増やさないこと
- 評価・状態・お気に入り・カラーラベルをsilent syncで保持すること
- 実ファイル削除とDB行削除、重複ID、既に消えたファイルを確認
- 180pxから260pxへ変更中も旧canvasを保持し、準備後に新サイズへ差し替えること
- 仮想グリッド再マウント後も既存メモリBitmapを即表示すること
- 100件超のタグ候補で候補表示を制限し、検索で目的タグへ到達できること
- 検索語から新規タグを作成し、その画像へ即付与できること
- 単体/複数用の削除アクション表示と実行

## ストレージ方針
表示用サムネイル/プレビュー画像は引き続きディスクへ生成・保存しません。メモリ内ImageBitmapのみです。

CI・Windows実ビルド・Portable artifactまで確認してからmergeします。