### PR TITLE
fix: 画像表示の待ち時間とブラウズ時の負荷を改善

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,8 @@ interface BootstrapPayload {
   settings?: Record<string, unknown>;
 }
 
-const AUTO_SYNC_INTERVAL_MS = 15_000;
+const AUTO_SYNC_INTERVAL_MS = 60_000;
+const AUTO_SYNC_INITIAL_DELAY_MS = 5_000;
 
 export default function App() {
   const [state, setState] = useState<AppState>(defaultState);
@@ -139,7 +140,7 @@ export default function App() {
       }
     };
 
-    const initialTimer = window.setTimeout(() => void run(), 1200);
+    const initialTimer = window.setTimeout(() => void run(), AUTO_SYNC_INITIAL_DELAY_MS);
     const interval = window.setInterval(() => void run(), AUTO_SYNC_INTERVAL_MS);
     const onFocus = () => void run();
     const onVisibility = () => { if (!document.hidden) void run(); };

--- a/frontend/src/components/ImageViewerModal.tsx
+++ b/frontend/src/components/ImageViewerModal.tsx
@@ -19,6 +19,8 @@ interface DragState {
   y: number;
 }
 
+const VIEWER_PREVIEW_MAX_PIXELS = 4_000_000;
+
 export function ImageViewerModal({
   asset,
   onClose,
@@ -217,6 +219,7 @@ export function ImageViewerModal({
             height={viewport.height}
             fit="contain"
             priority="high"
+            maxDecodePixels={VIEWER_PREVIEW_MAX_PIXELS}
             alt={asset.fileName}
             className="bg-black"
           />

--- a/frontend/src/components/MemoryImage.tsx
+++ b/frontend/src/components/MemoryImage.tsx
@@ -17,6 +17,7 @@ interface MemoryImageProps {
   height: number;
   fit?: ImageFit;
   priority?: ImageDecodePriority;
+  maxDecodePixels?: number;
   alt?: string;
   className?: string;
 }
@@ -69,6 +70,7 @@ export function MemoryImage({
   height,
   fit = "cover",
   priority = "normal",
+  maxDecodePixels,
   alt = "",
   className = "",
 }: MemoryImageProps) {
@@ -104,8 +106,14 @@ export function MemoryImage({
       };
     }
 
-    const targetWidth = Math.max(1, Math.round(width * pixelRatio));
-    const targetHeight = Math.max(1, Math.round(height * pixelRatio));
+    const rawTargetWidth = Math.max(1, Math.round(width * pixelRatio));
+    const rawTargetHeight = Math.max(1, Math.round(height * pixelRatio));
+    const rawPixels = rawTargetWidth * rawTargetHeight;
+    const decodeScale = maxDecodePixels && maxDecodePixels > 0 && rawPixels > maxDecodePixels
+      ? Math.sqrt(maxDecodePixels / rawPixels)
+      : 1;
+    const targetWidth = Math.max(1, Math.round(rawTargetWidth * decodeScale));
+    const targetHeight = Math.max(1, Math.round(rawTargetHeight * decodeScale));
     const request = {
       filePath,
       modifiedAtFs,
@@ -161,7 +169,7 @@ export function MemoryImage({
     return () => {
       cancelled = true;
     };
-  }, [filePath, modifiedAtFs, sourceWidth, sourceHeight, width, height, fit, priority, pixelRatio]);
+  }, [filePath, modifiedAtFs, sourceWidth, sourceHeight, width, height, fit, priority, maxDecodePixels, pixelRatio]);
 
   return (
     <div

--- a/frontend/src/components/ViewerGridV2.tsx
+++ b/frontend/src/components/ViewerGridV2.tsx
@@ -288,7 +288,7 @@ function GridCard({
         width={size}
         height={size}
         fit="cover"
-        priority="high"
+        priority="normal"
         alt={asset.fileName}
       />
       <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/85 via-black/25 to-transparent pointer-events-none" />
@@ -342,7 +342,7 @@ function ListRow({
         width={44}
         height={44}
         fit="cover"
-        priority="high"
+        priority="normal"
         alt={asset.fileName}
         className="rounded-lg flex-shrink-0"
       />

--- a/frontend/src/test/ImageViewerModal.test.tsx
+++ b/frontend/src/test/ImageViewerModal.test.tsx
@@ -3,7 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import type { AssetDTO } from "../api/client";
 
 vi.mock("../components/MemoryImage", () => ({
-  MemoryImage: ({ alt }: { alt: string }) => <div data-testid="viewer-preview">{alt}</div>,
+  MemoryImage: ({ alt, maxDecodePixels, priority }: { alt: string; maxDecodePixels?: number; priority?: string }) => (
+    <div
+      data-testid="viewer-preview"
+      data-max-decode-pixels={maxDecodePixels}
+      data-priority={priority}
+    >
+      {alt}
+    </div>
+  ),
 }));
 
 vi.mock("../api/client", () => ({
@@ -39,6 +47,14 @@ function pointerEvent(type: string, values: Record<string, number>) {
 }
 
 describe("ImageViewerModal", () => {
+  it("全画面プレビューを高優先度かつ過大でないBitmapサイズで要求する", () => {
+    render(<ImageViewerModal asset={asset} onClose={vi.fn()} />);
+
+    const preview = screen.getByTestId("viewer-preview");
+    expect(preview).toHaveAttribute("data-priority", "high");
+    expect(preview).toHaveAttribute("data-max-decode-pixels", "4000000");
+  });
+
   it("元画像の読み込み前でも拡大後のドラッグで表示位置を移動できる", async () => {
     render(<ImageViewerModal asset={asset} onClose={vi.fn()} />);
 

--- a/frontend/src/test/MemoryImage.test.tsx
+++ b/frontend/src/test/MemoryImage.test.tsx
@@ -41,6 +41,10 @@ describe("MemoryImage", () => {
     vi.mocked(getCachedMemoryBitmap).mockReset();
     vi.mocked(getCachedMemoryBitmap).mockReturnValue(null);
     drawImage = vi.fn();
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1,
+    });
     Object.defineProperty(globalThis, "createImageBitmap", {
       configurable: true,
       value: vi.fn(),
@@ -96,5 +100,29 @@ describe("MemoryImage", () => {
 
     exact.resolve(bitmap(260, 260));
     await waitFor(() => expect(drawImage.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+
+  it("高DPIの大きな表示でも指定した最大画素数を超えるBitmapを要求しない", async () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
+    vi.mocked(loadMemoryBitmap).mockResolvedValue(bitmap(1414, 707));
+
+    render(
+      <MemoryImage
+        filePath="C:\\images\\large.png"
+        width={2000}
+        height={1000}
+        maxDecodePixels={1_000_000}
+        alt="large.png"
+      />
+    );
+
+    await waitFor(() => expect(loadMemoryBitmap).toHaveBeenCalled());
+    expect(loadMemoryBitmap).toHaveBeenCalledWith(expect.objectContaining({
+      targetWidth: 1414,
+      targetHeight: 707,
+    }));
   });
 });

--- a/frontend/src/test/imagePipeline.test.ts
+++ b/frontend/src/test/imagePipeline.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { computeContainSize, computeCoverCrop } from "../utils/imagePipeline";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/client", () => ({
+  getLocalImageUrl: (path: string) => `/local?path=${encodeURIComponent(path)}`,
+}));
+
+import {
+  clearMemoryImageCache,
+  computeContainSize,
+  computeCoverCrop,
+  loadMemoryBitmap,
+} from "../utils/imagePipeline";
 
 describe("computeCoverCrop", () => {
   it("center-crops a wide image for a square preview", () => {
@@ -41,5 +51,62 @@ describe("computeContainSize", () => {
       width: 1,
       height: 1,
     });
+  });
+});
+
+describe("decode priority", () => {
+  afterEach(() => {
+    clearMemoryImageCache();
+    vi.unstubAllGlobals();
+  });
+
+  it("通常3件が実行中でもhigh要求を4番目の予約枠で先に開始する", async () => {
+    type PendingFetch = {
+      url: string;
+      resolve: (value: Response) => void;
+    };
+    const pending: PendingFetch[] = [];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => new Promise<Response>((resolve) => {
+      pending.push({ url: String(input), resolve });
+    }));
+    const close = vi.fn();
+    const createImageBitmapMock = vi.fn(async () => ({ width: 32, height: 32, close } as unknown as ImageBitmap));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("createImageBitmap", createImageBitmapMock);
+
+    const request = (name: string, priority: "normal" | "high") => loadMemoryBitmap({
+      filePath: `C:\\images\\${name}.png`,
+      modifiedAtFs: "2026-09-04T00:00:00Z",
+      sourceWidth: 100,
+      sourceHeight: 100,
+      targetWidth: 32,
+      targetHeight: 32,
+      fit: "cover",
+      priority,
+    });
+
+    const normal1 = request("normal-1", "normal");
+    const normal2 = request("normal-2", "normal");
+    const normal3 = request("normal-3", "normal");
+    const normal4 = request("normal-4", "normal");
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    const focused = request("focused", "high");
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    expect(pending[3]?.url).toContain("focused.png");
+
+    const response = () => ({
+      ok: true,
+      blob: async () => new Blob(["image"]),
+    } as Response);
+
+    pending.slice(0, 4).forEach((item) => item.resolve(response()));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+    expect(pending[4]?.url).toContain("normal-4.png");
+    pending[4]?.resolve(response());
+
+    await Promise.all([normal1, normal2, normal3, normal4, focused]);
   });
 });

--- a/frontend/src/utils/imagePipeline.ts
+++ b/frontend/src/utils/imagePipeline.ts
@@ -42,6 +42,7 @@ interface DecodeWaiter {
 }
 
 const cache = new Map<string, CacheEntry>();
+const cacheKeysBySource = new Map<string, Set<string>>();
 const inflight = new Map<string, Promise<ImageBitmap>>();
 let cacheBytes = 0;
 let activeDecodes = 0;
@@ -101,6 +102,36 @@ export function computeContainSize(
   };
 }
 
+function sourceKey(
+  filePath: string,
+  modifiedAtFs: string,
+  sourceWidth: number,
+  sourceHeight: number,
+  fit: ImageFit
+): string {
+  return [filePath, modifiedAtFs, sourceWidth, sourceHeight, fit].join("|");
+}
+
+function requestSourceKey(request: ImageBitmapRequest): string {
+  return sourceKey(
+    request.filePath,
+    request.modifiedAtFs ?? "",
+    request.sourceWidth ?? 0,
+    request.sourceHeight ?? 0,
+    request.fit
+  );
+}
+
+function entrySourceKey(entry: CacheEntry): string {
+  return sourceKey(
+    entry.filePath,
+    entry.modifiedAtFs,
+    entry.sourceWidth,
+    entry.sourceHeight,
+    entry.fit
+  );
+}
+
 function requestKey(request: ImageBitmapRequest): string {
   return [
     request.filePath,
@@ -111,6 +142,24 @@ function requestKey(request: ImageBitmapRequest): string {
     Math.round(request.targetHeight),
     request.fit,
   ].join("|");
+}
+
+function addToSourceIndex(key: string, entry: CacheEntry): void {
+  const indexed = entrySourceKey(entry);
+  let keys = cacheKeysBySource.get(indexed);
+  if (!keys) {
+    keys = new Set<string>();
+    cacheKeysBySource.set(indexed, keys);
+  }
+  keys.add(key);
+}
+
+function removeFromSourceIndex(key: string, entry: CacheEntry): void {
+  const indexed = entrySourceKey(entry);
+  const keys = cacheKeysBySource.get(indexed);
+  if (!keys) return;
+  keys.delete(key);
+  if (keys.size === 0) cacheKeysBySource.delete(indexed);
 }
 
 function touchCache(key: string, entry: CacheEntry): void {
@@ -124,6 +173,7 @@ function evictToBudget(): void {
     if (!oldest) break;
     const [key, entry] = oldest;
     cache.delete(key);
+    removeFromSourceIndex(key, entry);
     cacheBytes -= entry.bytes;
     entry.bitmap.close();
   }
@@ -134,10 +184,12 @@ function cacheBitmap(key: string, bitmap: ImageBitmap, request: ImageBitmapReque
   const previous = cache.get(key);
   if (previous) {
     cacheBytes -= previous.bytes;
+    removeFromSourceIndex(key, previous);
     if (previous.bitmap !== bitmap) previous.bitmap.close();
     cache.delete(key);
   }
-  cache.set(key, {
+
+  const entry: CacheEntry = {
     bitmap,
     bytes,
     filePath: request.filePath,
@@ -147,36 +199,31 @@ function cacheBitmap(key: string, bitmap: ImageBitmap, request: ImageBitmapReque
     targetWidth: Math.max(1, Math.round(request.targetWidth)),
     targetHeight: Math.max(1, Math.round(request.targetHeight)),
     fit: request.fit,
-  });
+  };
+
+  cache.set(key, entry);
+  addToSourceIndex(key, entry);
   cacheBytes += bytes;
   evictToBudget();
 }
 
 // Returns the nearest already-decoded representation of the same source image.
-// This is intentionally synchronous: a remounted grid card can paint the old
-// in-memory preview immediately while the requested larger bitmap is decoded.
+// Lookup is indexed by source, so remounting many cards does not scan the whole
+// 96 MiB LRU for every visible image.
 export function getCachedMemoryBitmap(request: ImageBitmapRequest): ImageBitmap | null {
-  const sourceWidth = request.sourceWidth ?? 0;
-  const sourceHeight = request.sourceHeight ?? 0;
-  const modifiedAtFs = request.modifiedAtFs ?? "";
   const targetWidth = Math.max(1, Math.round(request.targetWidth));
   const targetHeight = Math.max(1, Math.round(request.targetHeight));
+  const indexed = requestSourceKey(request);
+  const keys = cacheKeysBySource.get(indexed);
+  if (!keys || keys.size === 0) return null;
 
   let bestKey: string | null = null;
   let bestEntry: CacheEntry | null = null;
   let bestDistance = Number.POSITIVE_INFINITY;
 
-  for (const [key, entry] of cache) {
-    if (
-      entry.filePath !== request.filePath ||
-      entry.modifiedAtFs !== modifiedAtFs ||
-      entry.sourceWidth !== sourceWidth ||
-      entry.sourceHeight !== sourceHeight ||
-      entry.fit !== request.fit
-    ) {
-      continue;
-    }
-
+  for (const key of keys) {
+    const entry = cache.get(key);
+    if (!entry) continue;
     const distance = Math.abs(entry.targetWidth - targetWidth) + Math.abs(entry.targetHeight - targetHeight);
     if (distance < bestDistance) {
       bestDistance = distance;
@@ -308,6 +355,7 @@ export function clearMemoryImageCache(): void {
     entry.bitmap.close();
   }
   cache.clear();
+  cacheKeysBySource.clear();
   cacheBytes = 0;
 }
 

--- a/frontend/src/utils/imagePipeline.ts
+++ b/frontend/src/utils/imagePipeline.ts
@@ -23,6 +23,7 @@ export interface Rect {
 
 const CACHE_BUDGET_BYTES = 96 * 1024 * 1024;
 const MAX_CONCURRENT_DECODES = 4;
+const MAX_NORMAL_CONCURRENT_DECODES = 3;
 
 interface CacheEntry {
   bitmap: ImageBitmap;
@@ -237,29 +238,48 @@ export function getCachedMemoryBitmap(request: ImageBitmapRequest): ImageBitmap 
   return bestEntry.bitmap;
 }
 
+function canStartDecode(priority: ImageDecodePriority): boolean {
+  const limit = priority === "high" ? MAX_CONCURRENT_DECODES : MAX_NORMAL_CONCURRENT_DECODES;
+  return activeDecodes < limit;
+}
+
+function queueDecode(priority: ImageDecodePriority): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const waiter = { resolve, priority };
+    if (priority === "high") {
+      const firstNormal = decodeWaiters.findIndex((item) => item.priority === "normal");
+      if (firstNormal >= 0) decodeWaiters.splice(firstNormal, 0, waiter);
+      else decodeWaiters.push(waiter);
+    } else {
+      decodeWaiters.push(waiter);
+    }
+  });
+}
+
 function wakeNextDecode(): void {
-  const next = decodeWaiters.shift();
-  next?.resolve();
+  const index = decodeWaiters.findIndex((item) => canStartDecode(item.priority));
+  if (index < 0) return;
+  const [next] = decodeWaiters.splice(index, 1);
+  // Reserve the slot before resolving to prevent another task from taking it
+  // before the waiting promise continues on the microtask queue.
+  activeDecodes += 1;
+  next.resolve();
+}
+
+async function acquireDecodeSlot(priority: ImageDecodePriority): Promise<boolean> {
+  if (canStartDecode(priority)) {
+    activeDecodes += 1;
+    return false;
+  }
+  await queueDecode(priority);
+  return true;
 }
 
 async function withDecodeSlot<T>(
   work: () => Promise<T>,
   priority: ImageDecodePriority = "normal"
 ): Promise<T> {
-  if (activeDecodes >= MAX_CONCURRENT_DECODES) {
-    await new Promise<void>((resolve) => {
-      const waiter = { resolve, priority };
-      if (priority === "high") {
-        const firstNormal = decodeWaiters.findIndex((item) => item.priority === "normal");
-        if (firstNormal >= 0) decodeWaiters.splice(firstNormal, 0, waiter);
-        else decodeWaiters.push(waiter);
-      } else {
-        decodeWaiters.push(waiter);
-      }
-    });
-  }
-
-  activeDecodes += 1;
+  await acquireDecodeSlot(priority);
   try {
     return await work();
   } finally {


### PR DESCRIPTION
## 概要
PR #136 後の実機フィードバックで、右詳細パネルと拡大表示の画像が表示されるまで長く待つことがあり、ブラウズ中にも軽いカクつきが出る回帰を修正します。

## 原因
- 一覧グリッドの全表示画像を `high` priority decode にしたため、右詳細/全画面と同じ高優先度キューを一覧画像が占有していた
- 全画面プレビューが高DPI環境で画面サイズ×DPRそのままの大きなImageBitmapを作り、初回表示のCPU/メモリ負荷が大きかった
- サイズ変更時の即時プレースホルダー検索が、各カードごとに96MiB LRU全体を線形走査していた
- 自動差分同期が起動1.2秒後、その後15秒ごとに全ライブラリ走査を行い、画像ブラウズとI/Oが競合しやすかった

## 修正
- グリッド/リストの画像デコードを通常優先度へ戻し、右詳細/全画面の `high` priority が先に処理されるようにする
- 全画面用MemoryImageに4,000,000 pixelのデコード上限を追加。CSS表示サイズは維持し、拡大時は従来どおり元画像を読み込む
- メモリLRUの近似Bitmap検索をsource-key index化し、全キャッシュ走査を廃止
- silent syncを初回5秒後、定期60秒へ緩和。ウィンドウfocus/visibility復帰時の即時同期は維持

## 回帰テスト
- 高DPIの大きな表示でも `maxDecodePixels` を超えるBitmapを要求しない
- 全画面プレビューが `high` priority + 4,000,000 pixel capを指定する
- 既存のサイズ変更中canvas保持、再マウント時メモリプレビュー、拡大後dragテストを維持

CI・Windows実ビルド・Portable artifactまで確認してからdevelopへmergeします。