### PR TITLE
perf: preload viewer images for smooth scrolling

### DIFF
--- a/frontend/src/components/ViewerGrid.tsx
+++ b/frontend/src/components/ViewerGrid.tsx
@@ -5,9 +5,16 @@ import { getLocalImageUrl, listAssets } from "../api/client";
 import type { AssetDTO, AssetListRequest } from "../api/client";
 import { useApp } from "../App";
 import { formatFileSize } from "../utils/format";
+import {
+  computeViewerOverscan,
+  getViewerVisibleRange,
+  shouldFetchViewerPageAhead,
+  viewerImagePriority,
+  type ViewerImagePriority,
+} from "../utils/viewerPreload";
 import { MemoryImage } from "./MemoryImage";
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 200;
 const GAP = 8;
 
 interface ViewerGridProps {
@@ -19,13 +26,17 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
   const { state } = useApp();
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
   const [previewAsset, setPreviewAsset] = useState<AssetDTO | null>(null);
   const assetsRef = useRef<AssetDTO[]>([]);
 
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
-    const update = () => setContainerWidth(element.clientWidth);
+    const update = () => {
+      setContainerWidth(element.clientWidth);
+      setContainerHeight(element.clientHeight);
+    };
     const observer = new ResizeObserver(update);
     observer.observe(element);
     update();
@@ -106,21 +117,42 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
       ? Math.max(1, Math.floor((containerWidth + GAP) / (state.thumbnailSize + GAP)))
       : 4;
   const rowCount = Math.ceil(assets.length / columns);
+  const itemExtent = state.viewMode === "grid" ? state.thumbnailSize + GAP : 56;
+  const itemCount = state.viewMode === "grid" ? rowCount : assets.length;
+  const overscan = computeViewerOverscan(containerHeight, itemExtent);
 
   const virtualizer = useVirtualizer({
-    count: state.viewMode === "grid" ? rowCount : assets.length,
+    count: itemCount,
     getScrollElement: () => containerRef.current,
-    estimateSize: () => (state.viewMode === "grid" ? state.thumbnailSize + GAP : 56),
-    overscan: 1,
+    estimateSize: () => itemExtent,
+    overscan,
   });
   const virtualItems = virtualizer.getVirtualItems();
+  const visibleRange = getViewerVisibleRange(
+    virtualizer.scrollOffset ?? 0,
+    containerHeight,
+    itemExtent,
+    itemCount
+  );
 
   useEffect(() => {
     if (!hasNextPage || isFetchingNextPage) return;
     const last = virtualItems[virtualItems.length - 1];
-    const maximum = state.viewMode === "grid" ? rowCount : assets.length;
-    if (last && last.index >= maximum - 3) void fetchNextPage();
-  }, [virtualItems, rowCount, assets.length, state.viewMode, hasNextPage, isFetchingNextPage, fetchNextPage]);
+    if (
+      last &&
+      shouldFetchViewerPageAhead(last.index, itemCount, containerHeight, itemExtent)
+    ) {
+      void fetchNextPage();
+    }
+  }, [
+    virtualItems,
+    itemCount,
+    containerHeight,
+    itemExtent,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ]);
 
   const openPreview = useCallback((asset: AssetDTO) => setPreviewAsset(asset), []);
 
@@ -177,6 +209,11 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
             {virtualItems.map((virtualRow) => {
               const startIndex = virtualRow.index * columns;
               const rowAssets = assets.slice(startIndex, startIndex + columns);
+              const priority = viewerImagePriority(
+                virtualRow.index,
+                visibleRange.first,
+                visibleRange.last
+              );
               return (
                 <div
                   key={virtualRow.key}
@@ -201,6 +238,7 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
                         key={asset.id}
                         asset={asset}
                         size={state.thumbnailSize}
+                        priority={priority}
                         selected={state.selectedAssets.has(asset.id)}
                         onSelect={onSelectAsset}
                         onDoubleClick={openPreview}
@@ -216,10 +254,16 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
             {virtualItems.map((virtualItem) => {
               const asset = assets[virtualItem.index];
               if (!asset) return null;
+              const priority = viewerImagePriority(
+                virtualItem.index,
+                visibleRange.first,
+                visibleRange.last
+              );
               return (
                 <ViewerListItem
                   key={asset.id}
                   asset={asset}
+                  priority={priority}
                   selected={state.selectedAssets.has(asset.id)}
                   onSelect={onSelectAsset}
                   onDoubleClick={openPreview}
@@ -291,6 +335,7 @@ export function ViewerGrid({ onSelectAsset, onAssetsLoaded }: ViewerGridProps) {
 interface ViewerGridItemProps {
   asset: AssetDTO;
   size: number;
+  priority: ViewerImagePriority;
   selected: boolean;
   onSelect: (asset: AssetDTO, multi: boolean, range: boolean) => void;
   onDoubleClick: (asset: AssetDTO) => void;
@@ -299,6 +344,7 @@ interface ViewerGridItemProps {
 const ViewerGridItem = React.memo(function ViewerGridItem({
   asset,
   size,
+  priority,
   selected,
   onSelect,
   onDoubleClick,
@@ -323,6 +369,7 @@ const ViewerGridItem = React.memo(function ViewerGridItem({
         width={size}
         height={size}
         fit="cover"
+        priority={priority}
         alt={asset.fileName}
       />
 
@@ -359,6 +406,7 @@ const ViewerGridItem = React.memo(function ViewerGridItem({
 
 interface ViewerListItemProps {
   asset: AssetDTO;
+  priority: ViewerImagePriority;
   selected: boolean;
   onSelect: (asset: AssetDTO, multi: boolean, range: boolean) => void;
   onDoubleClick: (asset: AssetDTO) => void;
@@ -367,6 +415,7 @@ interface ViewerListItemProps {
 
 const ViewerListItem = React.memo(function ViewerListItem({
   asset,
+  priority,
   selected,
   onSelect,
   onDoubleClick,
@@ -390,6 +439,7 @@ const ViewerListItem = React.memo(function ViewerListItem({
         width={42}
         height={42}
         fit="cover"
+        priority={priority}
         alt={asset.fileName}
         className="rounded-lg flex-shrink-0"
       />
@@ -496,6 +546,7 @@ function ViewerPreview({
             width={viewport.width}
             height={viewport.height}
             fit="contain"
+            priority="high"
             alt={asset.fileName}
             className="bg-black"
           />

--- a/frontend/src/test/imagePipeline.test.ts
+++ b/frontend/src/test/imagePipeline.test.ts
@@ -60,6 +60,13 @@ describe("decode priority", () => {
     vi.unstubAllGlobals();
   });
 
+  function response(): Response {
+    return {
+      ok: true,
+      blob: async () => new Blob(["image"]),
+    } as Response;
+  }
+
   it("通常3件が実行中でもhigh要求を4番目の予約枠で先に開始する", async () => {
     type PendingFetch = {
       url: string;
@@ -75,7 +82,7 @@ describe("decode priority", () => {
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal("createImageBitmap", createImageBitmapMock);
 
-    const request = (name: string, priority: "normal" | "high") => loadMemoryBitmap({
+    const request = (name: string, priority: "prefetch" | "normal" | "high") => loadMemoryBitmap({
       filePath: `C:\\images\\${name}.png`,
       modifiedAtFs: "2026-09-04T00:00:00Z",
       sourceWidth: 100,
@@ -97,16 +104,59 @@ describe("decode priority", () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
     expect(pending[3]?.url).toContain("focused.png");
 
-    const response = () => ({
-      ok: true,
-      blob: async () => new Blob(["image"]),
-    } as Response);
-
     pending.slice(0, 4).forEach((item) => item.resolve(response()));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
     expect(pending[4]?.url).toContain("normal-4.png");
     pending[4]?.resolve(response());
 
     await Promise.all([normal1, normal2, normal3, normal4, focused]);
+  });
+
+  it("先読み待ちの画像が画面内に入ったら通常優先度へ昇格する", async () => {
+    type PendingFetch = {
+      url: string;
+      resolve: (value: Response) => void;
+    };
+    const pending: PendingFetch[] = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL) => new Promise<Response>((resolve) => {
+      pending.push({ url: String(input), resolve });
+    }));
+    const close = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("createImageBitmap", vi.fn(async () => ({ width: 32, height: 32, close } as unknown as ImageBitmap)));
+
+    const request = (name: string, priority: "prefetch" | "normal") => loadMemoryBitmap({
+      filePath: `C:\\images\\${name}.png`,
+      modifiedAtFs: "2026-09-04T00:00:00Z",
+      sourceWidth: 100,
+      sourceHeight: 100,
+      targetWidth: 32,
+      targetHeight: 32,
+      fit: "cover",
+      priority,
+    });
+
+    const first = request("prefetch-1", "prefetch");
+    const second = request("prefetch-2", "prefetch");
+    const third = request("prefetch-3", "prefetch");
+    const becomesVisible = request("prefetch-4", "prefetch");
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // Same bitmap request, now requested by a visible card. This must promote
+    // its queued work rather than waiting behind prefetch-3.
+    const visiblePromise = request("prefetch-4", "normal");
+    pending[0]?.resolve(response());
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    expect(pending[2]?.url).toContain("prefetch-4.png");
+
+    pending[1]?.resolve(response());
+    pending[2]?.resolve(response());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    expect(pending[3]?.url).toContain("prefetch-3.png");
+    pending[3]?.resolve(response());
+
+    await Promise.all([first, second, third, becomesVisible, visiblePromise]);
   });
 });

--- a/frontend/src/test/viewerPreload.test.ts
+++ b/frontend/src/test/viewerPreload.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeViewerOverscan,
+  getViewerVisibleRange,
+  shouldFetchViewerPageAhead,
+  viewerImagePriority,
+} from "../utils/viewerPreload";
+
+describe("viewer preload policy", () => {
+  it("keeps roughly two viewports mounted around the visible rows", () => {
+    expect(computeViewerOverscan(800, 200)).toBe(8);
+    expect(computeViewerOverscan(800, 100)).toBe(16);
+  });
+
+  it("distinguishes visible work from low-priority prefetch work", () => {
+    const range = getViewerVisibleRange(400, 600, 200, 100);
+    expect(range).toEqual({ first: 2, last: 4 });
+    expect(viewerImagePriority(1, range.first, range.last)).toBe("prefetch");
+    expect(viewerImagePriority(3, range.first, range.last)).toBe("normal");
+    expect(viewerImagePriority(5, range.first, range.last)).toBe("prefetch");
+  });
+
+  it("requests the next metadata page several viewports before the loaded edge", () => {
+    expect(shouldFetchViewerPageAhead(80, 100, 600, 100)).toBe(true);
+    expect(shouldFetchViewerPageAhead(40, 100, 600, 100)).toBe(false);
+  });
+});

--- a/frontend/src/utils/imagePipeline.ts
+++ b/frontend/src/utils/imagePipeline.ts
@@ -1,7 +1,7 @@
 import { getLocalImageUrl } from "../api/client";
 
 export type ImageFit = "cover" | "contain";
-export type ImageDecodePriority = "normal" | "high";
+export type ImageDecodePriority = "prefetch" | "normal" | "high";
 
 export interface ImageBitmapRequest {
   filePath: string;
@@ -21,9 +21,13 @@ export interface Rect {
   height: number;
 }
 
-const CACHE_BUDGET_BYTES = 96 * 1024 * 1024;
+// Keep enough recent decoded thumbnails for real viewer-style back/forward
+// scrolling while retaining a strict upper bound. This is memory-only; Lumine
+// still never writes generated thumbnails to disk.
+const CACHE_BUDGET_BYTES = 256 * 1024 * 1024;
 const MAX_CONCURRENT_DECODES = 4;
 const MAX_NORMAL_CONCURRENT_DECODES = 3;
+const MAX_PREFETCH_CONCURRENT_DECODES = 2;
 
 interface CacheEntry {
   bitmap: ImageBitmap;
@@ -40,6 +44,7 @@ interface CacheEntry {
 interface DecodeWaiter {
   resolve: () => void;
   priority: ImageDecodePriority;
+  key: string;
 }
 
 const cache = new Map<string, CacheEntry>();
@@ -209,8 +214,8 @@ function cacheBitmap(key: string, bitmap: ImageBitmap, request: ImageBitmapReque
 }
 
 // Returns the nearest already-decoded representation of the same source image.
-// Lookup is indexed by source, so remounting many cards does not scan the whole
-// 96 MiB LRU for every visible image.
+// This is what makes a remounted row display immediately when the user scrolls
+// back instead of flashing an empty frame while decoding again.
 export function getCachedMemoryBitmap(request: ImageBitmapRequest): ImageBitmap | null {
   const targetWidth = Math.max(1, Math.round(request.targetWidth));
   const targetHeight = Math.max(1, Math.round(request.targetHeight));
@@ -238,48 +243,68 @@ export function getCachedMemoryBitmap(request: ImageBitmapRequest): ImageBitmap 
   return bestEntry.bitmap;
 }
 
+function priorityRank(priority: ImageDecodePriority): number {
+  switch (priority) {
+    case "high": return 2;
+    case "normal": return 1;
+    default: return 0;
+  }
+}
+
 function canStartDecode(priority: ImageDecodePriority): boolean {
-  const limit = priority === "high" ? MAX_CONCURRENT_DECODES : MAX_NORMAL_CONCURRENT_DECODES;
+  const limit = priority === "high"
+    ? MAX_CONCURRENT_DECODES
+    : priority === "normal"
+      ? MAX_NORMAL_CONCURRENT_DECODES
+      : MAX_PREFETCH_CONCURRENT_DECODES;
   return activeDecodes < limit;
 }
 
-function queueDecode(priority: ImageDecodePriority): Promise<void> {
+function insertWaiter(waiter: DecodeWaiter): void {
+  const rank = priorityRank(waiter.priority);
+  const firstLower = decodeWaiters.findIndex((item) => priorityRank(item.priority) < rank);
+  if (firstLower >= 0) decodeWaiters.splice(firstLower, 0, waiter);
+  else decodeWaiters.push(waiter);
+}
+
+function queueDecode(key: string, priority: ImageDecodePriority): Promise<void> {
   return new Promise<void>((resolve) => {
-    const waiter = { resolve, priority };
-    if (priority === "high") {
-      const firstNormal = decodeWaiters.findIndex((item) => item.priority === "normal");
-      if (firstNormal >= 0) decodeWaiters.splice(firstNormal, 0, waiter);
-      else decodeWaiters.push(waiter);
-    } else {
-      decodeWaiters.push(waiter);
-    }
+    insertWaiter({ resolve, priority, key });
   });
+}
+
+function promoteQueuedDecode(key: string, priority: ImageDecodePriority): void {
+  const index = decodeWaiters.findIndex((item) => item.key === key);
+  if (index < 0) return;
+  const waiter = decodeWaiters[index];
+  if (priorityRank(priority) <= priorityRank(waiter.priority)) return;
+  decodeWaiters.splice(index, 1);
+  waiter.priority = priority;
+  insertWaiter(waiter);
 }
 
 function wakeNextDecode(): void {
   const index = decodeWaiters.findIndex((item) => canStartDecode(item.priority));
   if (index < 0) return;
   const [next] = decodeWaiters.splice(index, 1);
-  // Reserve the slot before resolving to prevent another task from taking it
-  // before the waiting promise continues on the microtask queue.
   activeDecodes += 1;
   next.resolve();
 }
 
-async function acquireDecodeSlot(priority: ImageDecodePriority): Promise<boolean> {
+async function acquireDecodeSlot(key: string, priority: ImageDecodePriority): Promise<void> {
   if (canStartDecode(priority)) {
     activeDecodes += 1;
-    return false;
+    return;
   }
-  await queueDecode(priority);
-  return true;
+  await queueDecode(key, priority);
 }
 
 async function withDecodeSlot<T>(
+  key: string,
   work: () => Promise<T>,
   priority: ImageDecodePriority = "normal"
 ): Promise<T> {
-  await acquireDecodeSlot(priority);
+  await acquireDecodeSlot(key, priority);
   try {
     return await work();
   } finally {
@@ -345,10 +370,17 @@ export async function loadMemoryBitmap(request: ImageBitmapRequest): Promise<Ima
     return cached.bitmap;
   }
 
+  const requestedPriority = request.priority ?? "normal";
   const pending = inflight.get(key);
-  if (pending) return pending;
+  if (pending) {
+    // An item that was only being prefetched may become visible during a fast
+    // scroll. Promote its queued decode instead of leaving the visible card
+    // waiting behind unrelated prefetch work.
+    promoteQueuedDecode(key, requestedPriority);
+    return pending;
+  }
 
-  const promise = withDecodeSlot(async () => {
+  const promise = withDecodeSlot(key, async () => {
     const response = await fetch(getLocalImageUrl(request.filePath), {
       cache: "no-store",
       credentials: "same-origin",
@@ -360,7 +392,7 @@ export async function loadMemoryBitmap(request: ImageBitmapRequest): Promise<Ima
     const bitmap = await createSizedBitmap(blob, request);
     cacheBitmap(key, bitmap, request);
     return bitmap;
-  }, request.priority ?? "normal");
+  }, requestedPriority);
 
   inflight.set(key, promise);
   try {
@@ -379,6 +411,6 @@ export function clearMemoryImageCache(): void {
   cacheBytes = 0;
 }
 
-export function getMemoryImageCacheStats(): { entries: number; bytes: number } {
-  return { entries: cache.size, bytes: cacheBytes };
+export function getMemoryImageCacheStats(): { entries: number; bytes: number; budgetBytes: number } {
+  return { entries: cache.size, bytes: cacheBytes, budgetBytes: CACHE_BUDGET_BYTES };
 }

--- a/frontend/src/utils/viewerPreload.ts
+++ b/frontend/src/utils/viewerPreload.ts
@@ -1,14 +1,17 @@
 export type ViewerImagePriority = "prefetch" | "normal";
 
 const MIN_OVERSCAN_ITEMS = 6;
-const MAX_OVERSCAN_ITEMS = 48;
-const OVERSCAN_SCREENS = 3;
+const MAX_OVERSCAN_ITEMS = 32;
+const OVERSCAN_SCREENS = 2;
 const FETCH_AHEAD_SCREENS = 4;
 
 function visibleItemCount(viewportSize: number, itemExtent: number): number {
   return Math.max(1, Math.ceil(Math.max(1, viewportSize) / Math.max(1, itemExtent)));
 }
 
+// Keep roughly two full viewports mounted above and below the visible range.
+// This is large enough for ordinary wheel/trackpad scrolling without turning
+// the entire library into DOM/canvas nodes.
 export function computeViewerOverscan(viewportSize: number, itemExtent: number): number {
   const visible = visibleItemCount(viewportSize, itemExtent);
   return Math.max(MIN_OVERSCAN_ITEMS, Math.min(MAX_OVERSCAN_ITEMS, visible * OVERSCAN_SCREENS));
@@ -31,6 +34,9 @@ export function viewerImagePriority(index: number, firstVisible: number, lastVis
   return index >= firstVisible && index <= lastVisible ? "normal" : "prefetch";
 }
 
+// Asset metadata is cheap compared with image decoding. Fetch it farther ahead
+// than bitmap overscan so a fast scrollbar drag does not hit the end of the
+// currently loaded page before the next page exists.
 export function shouldFetchViewerPageAhead(
   lastRenderedIndex: number,
   loadedItemCount: number,

--- a/frontend/src/utils/viewerPreload.ts
+++ b/frontend/src/utils/viewerPreload.ts
@@ -1,0 +1,44 @@
+export type ViewerImagePriority = "prefetch" | "normal";
+
+const MIN_OVERSCAN_ITEMS = 6;
+const MAX_OVERSCAN_ITEMS = 48;
+const OVERSCAN_SCREENS = 3;
+const FETCH_AHEAD_SCREENS = 4;
+
+function visibleItemCount(viewportSize: number, itemExtent: number): number {
+  return Math.max(1, Math.ceil(Math.max(1, viewportSize) / Math.max(1, itemExtent)));
+}
+
+export function computeViewerOverscan(viewportSize: number, itemExtent: number): number {
+  const visible = visibleItemCount(viewportSize, itemExtent);
+  return Math.max(MIN_OVERSCAN_ITEMS, Math.min(MAX_OVERSCAN_ITEMS, visible * OVERSCAN_SCREENS));
+}
+
+export function getViewerVisibleRange(
+  scrollOffset: number,
+  viewportSize: number,
+  itemExtent: number,
+  itemCount: number
+): { first: number; last: number } {
+  if (itemCount <= 0) return { first: 0, last: -1 };
+  const extent = Math.max(1, itemExtent);
+  const first = Math.max(0, Math.min(itemCount - 1, Math.floor(Math.max(0, scrollOffset) / extent)));
+  const last = Math.max(first, Math.min(itemCount - 1, Math.ceil((Math.max(0, scrollOffset) + Math.max(1, viewportSize)) / extent) - 1));
+  return { first, last };
+}
+
+export function viewerImagePriority(index: number, firstVisible: number, lastVisible: number): ViewerImagePriority {
+  return index >= firstVisible && index <= lastVisible ? "normal" : "prefetch";
+}
+
+export function shouldFetchViewerPageAhead(
+  lastRenderedIndex: number,
+  loadedItemCount: number,
+  viewportSize: number,
+  itemExtent: number
+): boolean {
+  if (loadedItemCount <= 0 || lastRenderedIndex < 0) return false;
+  const visible = visibleItemCount(viewportSize, itemExtent);
+  const threshold = Math.max(MIN_OVERSCAN_ITEMS, visible * FETCH_AHEAD_SCREENS);
+  return lastRenderedIndex >= loadedItemCount - threshold;
+}


### PR DESCRIPTION
## 概要
画像ビューワーとして、少しスクロールしただけで未ロードの黒い領域が見えたり、戻った時に再ロード感が出る問題を改善します。

## 変更
- 仮想化overscanを画面高ベースで前後約2画面へ拡張
- 画面外の画像を低優先度prefetch、画面内はnormalで処理
- prefetch待ちの画像が画面内へ入った時にキュー内で優先度昇格
- high（詳細/全画面）は引き続き最優先・専用枠を維持
- メモリLRUを96MiB→256MiBへ拡張し、スクロールバック時の再デコードを抑制
- 一覧メタデータPAGE_SIZEを200へ拡張
- 次ページを数画面前から先行取得
- overscan/fetch-aheadとdecode昇格の回帰テスト追加
- ディスクサムネイル/永続画像キャッシュは追加しない

## 完成条件
- frontend lint/typecheck/unit/build green
- backend CI green
- Windows通常版/Portable build green
- Portable artifact実物確認
- developへmerge後CI green